### PR TITLE
Fix VPR file importing by adding possible path

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -7,7 +7,7 @@ import ui.strings.initializeI18n
 import kotlin.browser.document
 
 const val APP_NAME = "UtaFormatix"
-const val APP_VERSION = "3.0"
+const val APP_VERSION = "3.0.1"
 
 suspend fun main() {
     initializeI18n(Language.English)


### PR DESCRIPTION
It seems sometime (maybe according to Locale or OS) the path of json inside vpr archive uses `/` instead of `\`.