### PR TITLE
hotfix for adding value in s5p files' displayOrder property

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -7,7 +7,7 @@ import ui.strings.initializeI18n
 import kotlin.browser.document
 
 const val APP_NAME = "UtaFormatix"
-const val APP_VERSION = "3.1"
+const val APP_VERSION = "3.1.1"
 
 suspend fun main() {
     initializeI18n(Language.English)

--- a/src/main/kotlin/io/S5p.kt
+++ b/src/main/kotlin/io/S5p.kt
@@ -105,6 +105,7 @@ object S5p {
     private fun generateTrack(track: model.Track, emptyTrack: Track): Track {
         return emptyTrack.copy(
             name = track.name,
+            displayOrder = track.id,
             notes = track.notes.map {
                 Note(
                     onset = it.tickOn * TICK_RATE,


### PR DESCRIPTION
- add value in s5p's "displayOrder" property to make the editor correctly recognize each track.
- update version