### PR TITLE
Import UTAU mode2 pitch data

### DIFF
--- a/src/main/kotlin/io/Ust.kt
+++ b/src/main/kotlin/io/Ust.kt
@@ -188,7 +188,6 @@ object Ust {
             }
         }
         val pitchData = notePitchDataList.ifEmpty { null }?.let { UtauTrackPitchData(it) }
-        console.log(pitchData)
         return FileParseResult(file, projectName, notes, tempos, pitchData)
     }
 

--- a/src/main/kotlin/process/Interpolation.kt
+++ b/src/main/kotlin/process/Interpolation.kt
@@ -1,0 +1,17 @@
+package process
+
+fun List<Pair<Long, Double>>.interpolateLinear(samplingIntervalTick: Long) =
+    this.takeIf { it.isNotEmpty() }
+        ?.zipWithNext()
+        ?.flatMap { (start, end) ->
+            val indexes = ((start.first + 1) until end.first)
+                .filter { (it - start.first) % samplingIntervalTick == 0L }
+            val points = indexes.map { x ->
+                val (x0, y0) = start
+                val (x1, y1) = end
+                val y = y0 + (x - x0) * (y1 - y0) / (x1 - x0)
+                x to y
+            }
+            listOf(start) + points
+        }
+        ?.plus(this.last())

--- a/src/main/kotlin/process/Interpolation.kt
+++ b/src/main/kotlin/process/Interpolation.kt
@@ -47,7 +47,6 @@ fun List<Pair<Long, Double>>.interpolateCosineEaseOut(samplingIntervalTick: Long
         val aFreq = kotlin.math.PI / (x1 - x0) / 2
         val amp = y0 - y1
         val phase = kotlin.math.PI / 2
-        console.log("start=$start, end=$end, afr=$aFreq, amp=$amp")
         indexes.map { x ->
             val y = amp * kotlin.math.cos(aFreq * (x - xOffset) + phase) + yOffset
             x to y

--- a/src/main/kotlin/process/Interpolation.kt
+++ b/src/main/kotlin/process/Interpolation.kt
@@ -1,17 +1,68 @@
 package process
 
 fun List<Pair<Long, Double>>.interpolateLinear(samplingIntervalTick: Long) =
-    this.takeIf { it.isNotEmpty() }
-        ?.zipWithNext()
-        ?.flatMap { (start, end) ->
-            val indexes = ((start.first + 1) until end.first)
-                .filter { (it - start.first) % samplingIntervalTick == 0L }
-            val points = indexes.map { x ->
-                val (x0, y0) = start
-                val (x1, y1) = end
-                val y = y0 + (x - x0) * (y1 - y0) / (x1 - x0)
-                x to y
-            }
-            listOf(start) + points
+    this.interpolate(samplingIntervalTick) { start, end, indexes ->
+        val (x0, y0) = start
+        val (x1, y1) = end
+        indexes.map { x ->
+            val y = y0 + (x - x0) * (y1 - y0) / (x1 - x0)
+            x to y
         }
-        ?.plus(this.last())
+    }
+
+fun List<Pair<Long, Double>>.interpolateCosineEaseInOut(samplingIntervalTick: Long) =
+    this.interpolate(samplingIntervalTick) { start, end, indexes ->
+        val (x0, y0) = start
+        val (x1, y1) = end
+        val xOffset = x0
+        val yOffset = (y0 + y1) / 2
+        val aFreq = kotlin.math.PI / (x1 - x0)
+        val amp = (y0 - y1) / 2
+        indexes.map { x ->
+            val y = amp * kotlin.math.cos(aFreq * (x - xOffset)) + yOffset
+            x to y
+        }
+    }
+
+fun List<Pair<Long, Double>>.interpolateCosineEaseIn(samplingIntervalTick: Long) =
+    this.interpolate(samplingIntervalTick) { start, end, indexes ->
+        val (x0, y0) = start
+        val (x1, y1) = end
+        val xOffset = x0
+        val yOffset = y1
+        val aFreq = kotlin.math.PI / (x1 - x0) / 2
+        val amp = y0 - y1
+        indexes.map { x ->
+            val y = amp * kotlin.math.cos(aFreq * (x - xOffset)) + yOffset
+            x to y
+        }
+    }
+
+fun List<Pair<Long, Double>>.interpolateCosineEaseOut(samplingIntervalTick: Long) =
+    this.interpolate(samplingIntervalTick) { start, end, indexes ->
+        val (x0, y0) = start
+        val (x1, y1) = end
+        val xOffset = x0
+        val yOffset = y0
+        val aFreq = kotlin.math.PI / (x1 - x0) / 2
+        val amp = y0 - y1
+        val phase = kotlin.math.PI / 2
+        console.log("start=$start, end=$end, afr=$aFreq, amp=$amp")
+        indexes.map { x ->
+            val y = amp * kotlin.math.cos(aFreq * (x - xOffset) + phase) + yOffset
+            x to y
+        }
+    }
+
+private fun List<Pair<Long, Double>>.interpolate(
+    samplingIntervalTick: Long,
+    mapping: (start: Pair<Long, Double>, end: Pair<Long, Double>, input: List<Long>) -> List<Pair<Long, Double>>
+) = this.takeIf { it.isNotEmpty() }
+    ?.zipWithNext()
+    ?.flatMap { (start, end) ->
+        val indexes = ((start.first + 1) until end.first)
+            .filter { (it - start.first) % samplingIntervalTick == 0L }
+        val points = mapping(start, end, indexes)
+        listOf(start) + points
+    }
+    ?.plus(this.last())

--- a/src/main/kotlin/process/pitch/SynthVPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/SynthVPitchConversion.kt
@@ -1,5 +1,7 @@
 package process.pitch
 
+import process.interpolateLinear
+
 private const val SAMPLING_INTERVAL_TICK = 4L
 
 fun processSvpInputPitchData(points: List<Pair<Long, Double>>, mode: String) =
@@ -11,27 +13,11 @@ private fun List<Pair<Long, Double>>.merge() = groupBy { it.first }
     .sortedBy { it.first }
 
 private fun List<Pair<Long, Double>>.interpolate(mode: String) = when (mode) {
-    "linear" -> this.interpolateLinear()
-    "cosine" -> this.interpolateLinear() // TODO: interpolateCosine
-    "cubic" -> this.interpolateLinear() // TODO: interpolateCubic
-    else -> this.interpolateLinear()
+    "linear" -> this.interpolateLinear(SAMPLING_INTERVAL_TICK)
+    "cosine" -> this.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: interpolateCosine
+    "cubic" -> this.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: interpolateCubic
+    else -> this.interpolateLinear(SAMPLING_INTERVAL_TICK)
 }
-
-private fun List<Pair<Long, Double>>.interpolateLinear() =
-    this.takeIf { it.isNotEmpty() }
-        ?.zipWithNext()
-        ?.flatMap { (start, end) ->
-            val indexes = ((start.first + 1) until end.first)
-                .filter { (it - start.first) % SAMPLING_INTERVAL_TICK == 0L }
-            val points = indexes.map { x ->
-                val (x0, y0) = start
-                val (x1, y1) = end
-                val y = y0 + (x - x0) * (y1 - y0) / (x1 - x0)
-                x to y
-            }
-            listOf(start) + points
-        }
-        ?.plus(this.last())
 
 fun appendPitchPointsForSvpOutput(points: List<Pair<Long, Double>>) =
     listOfNotNull(points.firstOrNull()) +

--- a/src/main/kotlin/process/pitch/SynthVPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/SynthVPitchConversion.kt
@@ -1,5 +1,6 @@
 package process.pitch
 
+import process.interpolateCosineEaseInOut
 import process.interpolateLinear
 
 private const val SAMPLING_INTERVAL_TICK = 4L
@@ -14,9 +15,9 @@ private fun List<Pair<Long, Double>>.merge() = groupBy { it.first }
 
 private fun List<Pair<Long, Double>>.interpolate(mode: String) = when (mode) {
     "linear" -> this.interpolateLinear(SAMPLING_INTERVAL_TICK)
-    "cosine" -> this.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: interpolateCosine
-    "cubic" -> this.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: interpolateCubic
-    else -> this.interpolateLinear(SAMPLING_INTERVAL_TICK)
+    "cosine" -> this.interpolateCosineEaseInOut(SAMPLING_INTERVAL_TICK)
+    "cubic" -> this.interpolateCosineEaseInOut(SAMPLING_INTERVAL_TICK) // TODO: interpolateCubic
+    else -> this.interpolateCosineEaseInOut(SAMPLING_INTERVAL_TICK)
 }
 
 fun appendPitchPointsForSvpOutput(points: List<Pair<Long, Double>>) =

--- a/src/main/kotlin/process/pitch/UtauPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauPitchConversion.kt
@@ -1,0 +1,14 @@
+package process.pitch
+
+data class UtauTrackPitchData(
+    val notes: List<UtauNotePitchData>
+)
+
+data class UtauNotePitchData(
+    val bpm: Double?,
+    val start: Double, // msec
+    val startShift: Double, // 10 cents
+    val widths: List<Double>, // msec
+    val shifts: List<Double>, // 10 cents
+    val types: List<String> // (blank)/s/r/j
+)

--- a/src/main/kotlin/process/pitch/UtauPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauPitchConversion.kt
@@ -1,7 +1,15 @@
 package process.pitch
 
+import model.Note
+import model.Pitch
+import model.TICKS_IN_FULL_NOTE
+import process.interpolateLinear
+import kotlin.math.roundToLong
+
+private const val SAMPLING_INTERVAL_TICK = 4L
+
 data class UtauTrackPitchData(
-    val notes: List<UtauNotePitchData>
+    val notes: List<UtauNotePitchData?>
 )
 
 data class UtauNotePitchData(
@@ -10,5 +18,78 @@ data class UtauNotePitchData(
     val startShift: Double, // 10 cents
     val widths: List<Double>, // msec
     val shifts: List<Double>, // 10 cents
-    val types: List<String> // (blank)/s/r/j
+    val curveTypes: List<String> // (blank)/s/r/j
 )
+
+fun pitchFromUtauTrack(pitchData: UtauTrackPitchData?, notes: List<Note>): Pitch? {
+    pitchData ?: return null
+    val notePitches = notes.zip(pitchData.notes)
+    var bpm = notePitches.firstOrNull { it.second?.bpm != null }?.second?.bpm ?: return null
+    val pitchPoints = mutableListOf<Pair<Long, Double>>()
+    var lastNote: Note? = null
+    var pendingPitchPoints = listOf<Pair<Long, Double>>()
+    for ((note, notePitch) in notePitches) {
+        val points = mutableListOf<Pair<Long, Double>>()
+        if (notePitch?.bpm != null) bpm = notePitch.bpm
+        if (notePitch != null) {
+            var tickPos = note.tickOn + tickFromMilliSec(notePitch.start, bpm)
+            points.add(tickPos to notePitch.startShift / 10)
+            for (index in notePitch.widths.indices) {
+                val width = notePitch.widths[index]
+                val shift = notePitch.shifts.getOrNull(index) ?: 0.0
+                val curveType = notePitch.curveTypes.getOrNull(index) ?: ""
+                tickPos += tickFromMilliSec(width, bpm)
+                val thisPoint = tickPos to (shift / 10)
+                val lastPoint = points.last()
+                val interpolatedPointList = interpolate(lastPoint, thisPoint, curveType)
+                points.addAll(interpolatedPointList.drop(1))
+            }
+        }
+        pitchPoints.addAll(pendingPitchPoints.filter { it.first < points.firstOrNull()?.first ?: Long.MAX_VALUE })
+        pendingPitchPoints = points.fixPointsAtLastNote(note, lastNote).shape()
+        lastNote = note
+    }
+    pitchPoints.addAll(pendingPitchPoints)
+    return Pitch(pitchPoints, isAbsolute = false)
+}
+
+private fun List<Pair<Long, Double>>.fixPointsAtLastNote(thisNote: Note, lastNote: Note?) =
+    if (lastNote == null) this
+    else {
+        val fixed = this.map {
+            if (it.first < thisNote.tickOn) it.first to (it.second + thisNote.key - lastNote.key) else it
+        }
+        val lastPoint = fixed.lastOrNull()
+        if (lastPoint != null && lastPoint.first < thisNote.tickOn) fixed + (thisNote.tickOn to 0.0)
+        else fixed
+    }
+
+private fun List<Pair<Long, Double>>.shape() =
+    this.sortedBy { it.first }
+        .fold(listOf<Pair<Long, Double>>()) { acc, point ->
+            val lastPoint = acc.lastOrNull()
+            if (lastPoint != null && lastPoint.first == point.first) {
+                acc.dropLast(1) + (lastPoint.first to ((lastPoint.second + point.second) / 2))
+            } else {
+                acc + point
+            }
+        }
+
+private fun interpolate(
+    lastPoint: Pair<Long, Double>,
+    thisPoint: Pair<Long, Double>,
+    curveType: String
+): List<Pair<Long, Double>> {
+    val input = listOf(lastPoint, thisPoint)
+    val output = when (curveType) {
+        "s" -> input.interpolateLinear(SAMPLING_INTERVAL_TICK)
+        "j" -> input.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: J curve?
+        "r" -> input.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: R curve?
+        else -> input.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: cosine?
+    }
+    return output.orEmpty()
+}
+
+private fun tickFromMilliSec(msec: Double, bpm: Double): Long {
+    return (msec * 60000 / bpm / (TICKS_IN_FULL_NOTE / 4)).roundToLong()
+}

--- a/src/main/kotlin/process/pitch/UtauPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauPitchConversion.kt
@@ -3,6 +3,9 @@ package process.pitch
 import model.Note
 import model.Pitch
 import model.TICKS_IN_FULL_NOTE
+import process.interpolateCosineEaseIn
+import process.interpolateCosineEaseInOut
+import process.interpolateCosineEaseOut
 import process.interpolateLinear
 import kotlin.math.roundToLong
 
@@ -83,9 +86,9 @@ private fun interpolate(
     val input = listOf(lastPoint, thisPoint)
     val output = when (curveType) {
         "s" -> input.interpolateLinear(SAMPLING_INTERVAL_TICK)
-        "j" -> input.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: J curve?
-        "r" -> input.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: R curve?
-        else -> input.interpolateLinear(SAMPLING_INTERVAL_TICK) // TODO: cosine?
+        "j" -> input.interpolateCosineEaseIn(SAMPLING_INTERVAL_TICK)
+        "r" -> input.interpolateCosineEaseOut(SAMPLING_INTERVAL_TICK)
+        else -> input.interpolateCosineEaseInOut(SAMPLING_INTERVAL_TICK)
     }
     return output.orEmpty()
 }

--- a/src/main/kotlin/process/pitch/UtauPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauPitchConversion.kt
@@ -91,5 +91,5 @@ private fun interpolate(
 }
 
 private fun tickFromMilliSec(msec: Double, bpm: Double): Long {
-    return (msec * 60000 / bpm / (TICKS_IN_FULL_NOTE / 4)).roundToLong()
+    return (msec * bpm * (TICKS_IN_FULL_NOTE / 4) / 60000).roundToLong()
 }


### PR DESCRIPTION
## Summary
- Import pitch data from UTAU mode2
- Implement cosine interpolation

### Cosine interpolation
![image](https://user-images.githubusercontent.com/7665216/104192692-8764f200-5462-11eb-8164-a0f6b3224097.png)
From left to right:
- cosineEaseInOut
   - `s curve` in UTAU
   - y = cos(x), x in (0, pi) 
- cosineEaseOut
   - `r curve` in UTAU
   - y = cos(x), x in (pi / 2, pi) 
- cosineEaseIn
   - `j curve` in UTAU
   - y = cos(x), x in (0, pi / 2) 

## References
https://w.atwiki.jp/utaou/pages/64.html#id_13fa83af