### PR TITLE
fix the issue that convertRelativity would turn 0 pitch values into n…

### DIFF
--- a/src/main/kotlin/process/pitch/PitchCalculation.kt
+++ b/src/main/kotlin/process/pitch/PitchCalculation.kt
@@ -38,7 +38,7 @@ private fun Pitch.convertRelativity(
                 val convertedValue =
                     if (value != null) {
                         if (isAbsolute) value - currentNoteKey
-                        else value.takeUnless { it == 0.0 }?.let { it + currentNoteKey }
+                        else value.takeUnless { it == 0.0 }?.let { it + currentNoteKey } ?: 0.0
                     } else 0.0
                 pos to convertedValue
             }.let {


### PR DESCRIPTION
fix the issue that convertRelativity would turn 0 pitch values into null. (As takeUnless would return null if statement satisfied, and ?. would keep null).
As this issue seems like will not affect current master branch, so I open this pull request on the develop branch to avoid feature errors.
But I'm not sure if it is a degisned behaviour (though I think the possibility is low), if it is, please let me know, and close this pull request.