### PR TITLE
Add link / button for release notes and frequently asked questions page

### DIFF
--- a/src/main/kotlin/ui/App.kt
+++ b/src/main/kotlin/ui/App.kt
@@ -42,6 +42,8 @@ import ui.external.materialui.tooltip
 import ui.external.materialui.typography
 import ui.model.Stage
 import ui.model.StageInfo
+import ui.strings.Strings.FaqUrl
+import ui.strings.Strings.FrequentlyAskedQuestionTooltip
 import ui.strings.Strings.ReportFeedbackTooltip
 import ui.strings.Strings.ReportUrl
 import ui.strings.string
@@ -103,6 +105,19 @@ class App : RComponent<RProps, AppState>() {
                             }
                             +"v$APP_VERSION"
                         }
+                    }
+                }
+                tooltip {
+                    attrs {
+                        title = string(FrequentlyAskedQuestionTooltip)
+                        interactive = false
+                    }
+                    button {
+                        attrs {
+                            color = Color.inherit
+                            onClick = { window.open(string(FaqUrl), target = "_blank") }
+                        }
+                        Icons.liveHelp {}
                     }
                 }
                 tooltip {

--- a/src/main/kotlin/ui/App.kt
+++ b/src/main/kotlin/ui/App.kt
@@ -30,6 +30,7 @@ import ui.external.materialui.StepIconPropsClasses
 import ui.external.materialui.Style
 import ui.external.materialui.TypographyVariant
 import ui.external.materialui.appBar
+import ui.external.materialui.button
 import ui.external.materialui.container
 import ui.external.materialui.cssBaseline
 import ui.external.materialui.fab
@@ -37,9 +38,11 @@ import ui.external.materialui.step
 import ui.external.materialui.stepLabel
 import ui.external.materialui.stepper
 import ui.external.materialui.toolbar
+import ui.external.materialui.tooltip
 import ui.external.materialui.typography
 import ui.model.Stage
 import ui.model.StageInfo
+import ui.strings.Strings.ReportFeedbackTooltip
 import ui.strings.Strings.ReportUrl
 import ui.strings.string
 import kotlin.browser.window
@@ -102,12 +105,18 @@ class App : RComponent<RProps, AppState>() {
                         }
                     }
                 }
-                ui.external.materialui.button {
+                tooltip {
                     attrs {
-                        color = Color.inherit
-                        onClick = { window.open(string(ReportUrl), target = "_blank") }
+                        title = string(ReportFeedbackTooltip)
+                        interactive = false
                     }
-                    Icons.feedback {}
+                    button {
+                        attrs {
+                            color = Color.inherit
+                            onClick = { window.open(string(ReportUrl), target = "_blank") }
+                        }
+                        Icons.feedback {}
+                    }
                 }
                 child(LanguageSelector::class) {
                     attrs {

--- a/src/main/kotlin/ui/CustomFooter.kt
+++ b/src/main/kotlin/ui/CustomFooter.kt
@@ -42,6 +42,15 @@ class CustomFooter : RComponent<RProps, RState>() {
                     }
                     +"View Source Code on GitHub"
                 }
+                +" | "
+                link {
+                    attrs {
+                        href = "https://gist.github.com/sdercolin/512db280480072f22cf1d462401eb1a0"
+                        target = "_blank"
+                        color = Color.inherit
+                    }
+                    +"Release Notes"
+                }
             }
         }
     }

--- a/src/main/kotlin/ui/external/materialui/Icons.kt
+++ b/src/main/kotlin/ui/external/materialui/Icons.kt
@@ -15,6 +15,7 @@ object Icons {
     val arrowBack = iconModule.ArrowBack.unsafeCast<RClass<IconProps>>()
     val help = iconModule.HelpOutline.unsafeCast<RClass<IconProps>>()
     val warning = iconModule.ErrorOutline.unsafeCast<RClass<IconProps>>()
+    val liveHelp = iconModule.LiveHelp.unsafeCast<RClass<IconProps>>()
 }
 
 external interface IconProps : RProps {

--- a/src/main/kotlin/ui/strings/Strings.kt
+++ b/src/main/kotlin/ui/strings/Strings.kt
@@ -12,9 +12,14 @@ enum class Strings(val en: String, val ja: String, val zhCN: String) {
         zhCN = SimplifiedChinese.displayName
     ),
     ReportFeedbackTooltip(
-        en = "Send feedback.",
+        en = "Send feedback",
         ja = "フィードバックを送信",
         zhCN = "提交反馈"
+    ),
+    FrequentlyAskedQuestionTooltip(
+        en = "Frequently Asked Questions",
+        ja = "よくある質問",
+        zhCN = "常见问题解答"
     ),
     ImportProjectCaption(
         en = "Import Project",
@@ -145,6 +150,11 @@ enum class Strings(val en: String, val ja: String, val zhCN: String) {
         en = "https://forms.gle/3Es3ZomcYKNHWBvp6",
         ja = "https://forms.gle/kDY9chZBjGATXqpE8",
         zhCN = "https://forms.gle/nJVdrsfwMhbNXEYUA"
+    ),
+    FaqUrl(
+        en = "https://gist.githubusercontent.com/sdercolin/4d835e7e201a39504f5321f67d254209/",
+        ja = "https://gist.githubusercontent.com/sdercolin/f1de7c1f7a894f1fc8f77b17f3e8f77d/",
+        zhCN = "https://gist.githubusercontent.com/sdercolin/1a940a1357e2a6a5c10561482536bdba/"
     ),
     ImportWarningTitle(
         en = "The following exceptions happened during the import process.",

--- a/src/main/kotlin/ui/strings/Strings.kt
+++ b/src/main/kotlin/ui/strings/Strings.kt
@@ -11,6 +11,11 @@ enum class Strings(val en: String, val ja: String, val zhCN: String) {
         ja = Japanese.displayName,
         zhCN = SimplifiedChinese.displayName
     ),
+    ReportFeedbackTooltip(
+        en = "Send feedback.",
+        ja = "フィードバックを送信",
+        zhCN = "提交反馈"
+    ),
     ImportProjectCaption(
         en = "Import Project",
         ja = "プロジェクトをインポート",


### PR DESCRIPTION
* Add link for the external page of "release notes" on page's footer.
* Add button for the external page of "frequently asked questions" on the toolbar.