### PR TITLE
Simplify model structures for projects using json

### DIFF
--- a/src/main/kotlin/io/Ppsf.kt
+++ b/src/main/kotlin/io/Ppsf.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.await
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import model.DEFAULT_LYRIC
 import model.Format
 import model.ImportWarning
@@ -84,8 +85,8 @@ object Ppsf {
                 id = 0,
                 key = it.noteNumber,
                 lyric = it.lyric?.takeUnless { lyric -> lyric.isBlank() } ?: DEFAULT_LYRIC,
-                tickOn = it.pos.toLong(),
-                tickOff = it.pos.toLong() + it.length.toLong()
+                tickOn = it.pos,
+                tickOff = it.pos + it.length
             )
         }
         return model.Track(
@@ -119,143 +120,35 @@ object Ppsf {
     @Serializable
     private data class Root(
         @SerialName("app_ver") val appVer: String,
-        @SerialName("gui_settings") val guiSettings: GuiSettings? = null,
+        @SerialName("gui_settings") val guiSettings: JsonElement? = null,
         @SerialName("ppsf_ver") val ppsfVer: String,
         @SerialName("project") val project: InnerProject
     )
 
     @Serializable
-    private data class GuiSettings(
-        @SerialName("file-fullpath") val fileFullpath: String? = null,
-        @SerialName("playback-position") val playbackPosition: Int? = null,
-        @SerialName("project-length") val projectLength: Int? = null,
-        @SerialName("track-editor") val trackEditor: TrackEditor? = null
-    )
-
-    @Serializable
     private data class InnerProject(
-        @SerialName("audio_track") val audioTrack: List<AudioTrack> = listOf(),
-        @SerialName("block_size") val blockSize: Int? = null,
+        @SerialName("audio_track") val audioTrack: JsonElement? = null,
+        @SerialName("block_size") val blockSize: JsonElement? = null,
         @SerialName("dvl_track") val dvlTrack: List<DvlTrack> = listOf(),
-        @SerialName("loop_point") val loopPoint: LoopPoint? = null,
+        @SerialName("loop_point") val loopPoint: JsonElement? = null,
         @SerialName("meter") val meter: Meter,
-        @SerialName("metronome") val metronome: Metronome? = null,
+        @SerialName("metronome") val metronome: JsonElement? = null,
         @SerialName("name") val name: String? = null,
         @SerialName("sampling_rate") val samplingRate: Int,
-        @SerialName("singer_table") val singerTable: List<String> = listOf(), // unknown
+        @SerialName("singer_table") val singerTable: JsonElement? = null,
         @SerialName("tempo") val tempo: Tempo,
-        @SerialName("vocaloid_track") val vocaloidTrack: List<String> = listOf() // unknown
-    )
-
-    @Serializable
-    private data class TrackEditor(
-        @SerialName("event-tracks") val eventTracks: List<EventTrack> = listOf(),
-        @SerialName("header-width") val headerWidth: Int? = null,
-        @SerialName("horizontal-scale") val horizontalScale: Double? = null,
-        @SerialName("horizontal-scroll") val horizontalScroll: Int? = null,
-        @SerialName("tempo-track") val tempoTrack: TempoTrack? = null,
-        @SerialName("height") val height: Int? = null,
-        @SerialName("width") val width: Int? = null,
-        @SerialName("x") val x: Int? = null,
-        @SerialName("y") val y: Int? = null
-    )
-
-    @Serializable
-    private data class EventTrack(
-        @SerialName("curve-points") val curvePoints: List<CurvePoint> = listOf(),
-        @SerialName("fsm-effects") val fsmEffects: List<FsmEffect> = listOf(),
-        @SerialName("height") val height: Int? = null,
-        @SerialName("index") val index: Int? = null,
-        @SerialName("mute-solo") val muteSolo: Int? = null,
-        @SerialName("notes") val notes: List<Note> = listOf(),
-        @SerialName("regions") val regions: List<Region> = listOf(),
-        @SerialName("sub-tracks") val subTracks: List<SubTrack> = listOf(),
-        @SerialName("total-height") val totalHeight: Int? = null,
-        @SerialName("track-type") val trackType: Int? = null,
-        @SerialName("vertical-scale") val verticalScale: Double? = null,
-        @SerialName("vertical-scroll") val verticalScroll: Int? = null
-    )
-
-    @Serializable
-    private data class TempoTrack(
-        @SerialName("height") val height: Int? = null,
-        @SerialName("vertical-scale") val verticalScale: Double? = null,
-        @SerialName("vertical-scroll") val verticalScroll: Int? = null
-    )
-
-    @Serializable
-    private data class FsmEffect(
-        @SerialName("parameters") val parameters: List<FsmEffectParameter> = listOf(),
-        @SerialName("plugin-id") val pluginId: Int? = null,
-        @SerialName("plugin-name") val pluginName: String? = null,
-        @SerialName("power-state") val powerState: Boolean? = null,
-        @SerialName("program-name") val programName: String? = null,
-        @SerialName("program-number") val programNumber: Int? = null,
-        @SerialName("version") val version: String? = null
-    )
-
-    @Serializable
-    private data class Note(
-        @SerialName("event_index") val eventIndex: Int? = null,
-        @SerialName("language") val language: Int? = null,
-        @SerialName("length") val length: Int? = null,
-        @SerialName("muted") val muted: Boolean? = null,
-        @SerialName("note_env_preset_id") val noteEnvPresetId: Int? = null,
-        @SerialName("note_gain_value") val noteGainValue: Int? = null,
-        @SerialName("region-index") val regionIndex: Int? = null,
-        @SerialName("syllables") val syllables: List<Syllable> = listOf(),
-        @SerialName("vibrato_preset_id") val vibratoPresetId: Int? = null,
-        @SerialName("voice_color_id") val voiceColorId: Int? = null,
-        @SerialName("voice_release_id") val voiceReleaseId: Int? = null
-    )
-
-    @Serializable
-    private data class Region(
-        @SerialName("auto-expand-left") val autoExpandLeft: Boolean? = null,
-        @SerialName("auto-expand-right") val autoExpandRight: Boolean? = null,
-        @SerialName("length") val length: Int? = null,
-        @SerialName("muted") val muted: Boolean? = null,
-        @SerialName("name") val name: String? = null,
-        @SerialName("position") val position: Int? = null,
-        @SerialName("z-order") val zOrder: Int? = null
-    )
-
-    @Serializable
-    private data class FsmEffectParameter(
-        @SerialName("constant") val constant: Int? = null,
-        @SerialName("name") val name: String? = null,
-        @SerialName("sequence") val sequence: List<FsmEffectSequenceEvent> = listOf(),
-        @SerialName("use_sequence") val useSequence: Boolean? = null
-    )
-
-    @Serializable
-    private data class Syllable(
-        @SerialName("footer-text") val footerText: String? = null,
-        @SerialName("header-text") val headerText: String? = null,
-        @SerialName("is-list-end") val isListEnd: Boolean? = null,
-        @SerialName("is-list-top") val isListTop: Boolean? = null,
-        @SerialName("is-word-end") val isWordEnd: Boolean? = null,
-        @SerialName("is-word-top") val isWordTop: Boolean? = null,
-        @SerialName("lyric-text") val lyricText: String? = null,
-        @SerialName("symbols-text") val symbolsText: String? = null
+        @SerialName("vocaloid_track") val vocaloidTrack: JsonElement? = null
     )
 
     @Serializable
     private data class DvlTrack(
         @SerialName("enabled") val enabled: Boolean? = null,
         @SerialName("events") val events: List<Event> = listOf(),
-        @SerialName("mixer") val mixer: Mixer? = null,
+        @SerialName("mixer") val mixer: JsonElement? = null,
         @SerialName("name") val name: String? = null,
-        @SerialName("parameters") val parameters: List<DvlParameter> = listOf(),
+        @SerialName("parameters") val parameters: JsonElement? = null,
         @SerialName("plugin_output_bus_index") val pluginOutputBusIndex: Int? = null,
-        @SerialName("singer") val singer: Singer? = null
-    )
-
-    @Serializable
-    private data class LoopPoint(
-        @SerialName("begin") val begin: Int? = null,
-        @SerialName("enable") val enable: Boolean? = null,
-        @SerialName("end") val end: Int? = null
+        @SerialName("singer") val singer: JsonElement? = null
     )
 
     @Serializable
@@ -263,12 +156,6 @@ object Ppsf {
         @SerialName("const") val const: MeterConstValue,
         @SerialName("sequence") val sequence: List<MeterSequenceEvent>? = null,
         @SerialName("use_sequence") val useSequence: Boolean
-    )
-
-    @Serializable
-    private data class Metronome(
-        @SerialName("enable") val enable: Boolean? = null,
-        @SerialName("wav") val wav: String? = null
     )
 
     @Serializable
@@ -281,101 +168,22 @@ object Ppsf {
     @Serializable
     private data class Event(
         @SerialName("adjust_speed") val adjustSpeed: Boolean? = null,
-        @SerialName("attack_speed_rate") val attackSpeedRate: Int? = null,
-        @SerialName("consonant_rate") val consonantRate: Int? = null,
-        @SerialName("consonant_speed_rate") val consonantSpeedRate: Int? = null,
+        @SerialName("attack_speed_rate") val attackSpeedRate: JsonElement? = null,
+        @SerialName("consonant_rate") val consonantRate: JsonElement? = null,
+        @SerialName("consonant_speed_rate") val consonantSpeedRate: JsonElement? = null,
         @SerialName("enabled") val enabled: Boolean? = null,
-        @SerialName("length") val length: Int,
+        @SerialName("length") val length: Long,
         @SerialName("lyric") val lyric: String? = null,
         @SerialName("note_number") val noteNumber: Int,
-        @SerialName("note_off_pit_envelope") val noteOffPitEnvelope: NoteOffPitEnvelope? = null,
-        @SerialName("note_on_pit_envelope") val noteOnPitEnvelope: NoteOnPitEnvelope? = null,
-        @SerialName("portamento_envelope") val portamentoEnvelope: PortamentoEnvelope? = null,
-        @SerialName("portamento_type") val portamentoType: Int? = null,
-        @SerialName("pos") val pos: Int,
+        @SerialName("note_off_pit_envelope") val noteOffPitEnvelope: JsonElement? = null,
+        @SerialName("note_on_pit_envelope") val noteOnPitEnvelope: JsonElement? = null,
+        @SerialName("portamento_envelope") val portamentoEnvelope: JsonElement? = null,
+        @SerialName("portamento_type") val portamentoType: JsonElement? = null,
+        @SerialName("pos") val pos: Long,
         @SerialName("protected") val isProtected: Boolean? = null,
-        @SerialName("release_speed_rate") val releaseSpeedRate: Int? = null,
+        @SerialName("release_speed_rate") val releaseSpeedRate: JsonElement? = null,
         @SerialName("symbols") val symbols: String? = null,
-        @SerialName("vcl_like_note_off") val vclLikeNoteOff: Boolean? = null
-    )
-
-    @Serializable
-    private data class Mixer(
-        @SerialName("gain") val gain: Gain? = null,
-        @SerialName("mixer_type") val mixerType: String? = null,
-        @SerialName("panpot") val panpot: Panpot? = null
-    )
-
-    @Serializable
-    private data class DvlParameter(
-        @SerialName("base-sequence") val baseSequence: BaseSequence? = null
-        // not implemented in PPS yet
-        // @SerialName("layers") val layers: List<String> = listOf()
-    )
-
-    @Serializable
-    private data class Singer(
-        @SerialName("character_name") val characterName: String? = null,
-        @SerialName("do_extrapolation") val doExtrapolation: Boolean? = null,
-        @SerialName("frame_shift") val frameShift: Double? = null,
-        @SerialName("gender") val gender: Int? = null,
-        @SerialName("language_id") val languageId: Int? = null,
-        @SerialName("library_id") val libraryId: String? = null,
-        @SerialName("name") val name: String? = null,
-        @SerialName("singer_name") val singerName: String? = null,
-        @SerialName("stationaly_type") val stationalyType: String? = null,
-        @SerialName("synthesis_version") val synthesisVersion: String? = null,
-        @SerialName("tail_silent") val tailSilent: Double? = null,
-        @SerialName("vprm_morph_mode") val vprmMorphMode: String? = null
-    )
-
-    @Serializable
-    private data class NoteOffPitEnvelope(
-        @SerialName("length") val length: Int? = null,
-        @SerialName("offset") val offset: Int? = null,
-        // unknown
-        // @SerialName("points") val points: List<String> = listOf(),
-        @SerialName("use_length") val useLength: Boolean? = null
-    )
-
-    @Serializable
-    private data class NoteOnPitEnvelope(
-        @SerialName("length") val length: Int? = null,
-        @SerialName("offset") val offset: Int? = null,
-        // unknown
-        // @SerialName("points") val points: List<String> = listOf(),
-        @SerialName("use_length") val useLength: Boolean? = null
-    )
-
-    @Serializable
-    private data class PortamentoEnvelope(
-        @SerialName("length") val length: Int? = null,
-        @SerialName("offset") val offset: Int? = null,
-        // unknown
-        // @SerialName("points") val points: List<String> = listOf(),
-        @SerialName("use_length") val useLength: Boolean? = null
-    )
-
-    @Serializable
-    private data class Gain(
-        @SerialName("base-sequence") val baseSequence: BaseSequence? = null
-        // not implemented in PPS yet
-        // @SerialName("layers") val layers: List<String> = listOf()
-    )
-
-    @Serializable
-    private data class Panpot(
-        @SerialName("base-sequence") val baseSequence: BaseSequence? = null
-        // not implemented in PPS yet
-        // @SerialName("layers") val layers: List<String> = listOf()
-    )
-
-    @Serializable
-    private data class BaseSequence(
-        @SerialName("constant") val constant: Int? = null,
-        @SerialName("name") val name: String? = null,
-        @SerialName("sequence") val sequence: List<BaseSequenceEvent> = listOf(),
-        @SerialName("use_sequence") val useSequence: Boolean? = null
+        @SerialName("vcl_like_note_off") val vclLikeNoteOff: JsonElement? = null
     )
 
     @Serializable
@@ -396,68 +204,5 @@ object Ppsf {
         @SerialName("curve_type") val curveType: Int? = null,
         @SerialName("tick") val tick: Int,
         @SerialName("value") val value: Int
-    )
-
-    @Serializable
-    private data class SubTrack(
-        @SerialName("height") val height: Int? = null,
-        @SerialName("sub-track-category") val subTrackCategory: Int? = null,
-        @SerialName("sub-track-id") val subTrackId: Int? = null
-    )
-
-    @Serializable
-    private data class CurvePoint(
-        @SerialName("sequence") val sequence: List<CurvePointEvent> = listOf(),
-        @SerialName("sub-track-category") val subTrackCategory: Int? = null,
-        @SerialName("sub-track-id") val subTrackId: Int? = null
-    )
-
-    @Serializable
-    private data class CurvePointEvent(
-        @SerialName("border-type") val borderType: Int? = null,
-        @SerialName("note-index") val noteIndex: Int? = null,
-        @SerialName("region-index") val regionIndex: Int? = null
-    )
-
-    @Serializable
-    private data class BaseSequenceEvent(
-        @SerialName("curve_type") val curveType: Int? = null,
-        @SerialName("pos") val pos: Int? = null,
-        @SerialName("value") val value: Int? = null
-    )
-
-    @Serializable
-    private data class AudioTrack(
-        @SerialName("block_size") val blockSize: Int? = null,
-        @SerialName("enabled") val enabled: Boolean? = null,
-        @SerialName("events") val events: List<AudioTrackEvent>? = null,
-        @SerialName("input_channel") val inputChannel: Int? = null,
-        @SerialName("mixer") val mixer: Mixer? = null,
-        @SerialName("name") val name: String? = null,
-        @SerialName("output_channel") val outputChannel: Int? = null,
-        @SerialName("sampling_rate") val samplingRate: Int? = null
-    )
-
-    @Serializable
-    private data class AudioTrackEvent(
-        @SerialName("enabled") val enabled: Boolean? = null,
-        @SerialName("file_audio_data") val fileAudioData: FileAudioData? = null,
-        @SerialName("playback_offset_sample") val playbackOffsetSample: Int? = null,
-        @SerialName("tick_length") val tickLength: Int? = null,
-        @SerialName("tick_pos") val tickPos: Int? = null
-    )
-
-    @Serializable
-    private data class FileAudioData(
-        @SerialName("file_path") val filePath: String? = null,
-        @SerialName("tempo") val tempo: Int? = null
-    )
-
-    @Serializable
-    private data class FsmEffectSequenceEvent(
-        @SerialName("curve_type") val curveType: Int? = null,
-        @SerialName("pos") val pos: Int? = null,
-        @SerialName("region-index") val regionIndex: Int? = null,
-        @SerialName("value") val value: Int? = null
     )
 }

--- a/src/main/kotlin/io/S5p.kt
+++ b/src/main/kotlin/io/S5p.kt
@@ -4,6 +4,7 @@ import external.Resources
 import kotlin.math.roundToLong
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import model.DEFAULT_LYRIC
 import model.ExportNotification
 import model.ExportResult
@@ -171,18 +172,12 @@ object S5p {
 
     @Serializable
     private data class Project(
-        var instrumental: Instrumental? = null,
+        var instrumental: JsonElement? = null,
         var meter: List<Meter> = listOf(),
-        var mixer: Mixer? = null,
+        var mixer: JsonElement? = null,
         var tempo: List<Tempo> = listOf(),
         var tracks: List<Track> = listOf(),
         var version: Int? = null
-    )
-
-    @Serializable
-    private data class Instrumental(
-        var filename: String? = null,
-        var offset: Double? = null
     )
 
     @Serializable
@@ -190,14 +185,6 @@ object S5p {
         var beatGranularity: Int,
         var beatPerMeasure: Int,
         var measure: Int
-    )
-
-    @Serializable
-    private data class Mixer(
-        var gainInstrumentalDecibel: Double? = null,
-        var gainVocalMasterDecibel: Double? = null,
-        var instrumentalMuted: Boolean? = null,
-        var vocalMasterMuted: Boolean? = null
     )
 
     @Serializable
@@ -209,26 +196,13 @@ object S5p {
     @Serializable
     private data class Track(
         var color: String? = null,
-        var dbDefaults: DbDefaults? = null,
+        var dbDefaults: JsonElement? = null,
         var dbName: String? = null,
         var displayOrder: Int? = null,
-        var mixer: MixerX? = null,
+        var mixer: JsonElement? = null,
         var name: String? = null,
         var notes: List<Note> = listOf(),
         var parameters: Parameters? = null
-    )
-
-    @Serializable
-    private class DbDefaults
-
-    @Serializable
-    private data class MixerX(
-        var display: Boolean? = null,
-        var engineOn: Boolean? = null,
-        var gainDecibel: Double? = null,
-        var muted: Boolean? = null,
-        var pan: Double? = null,
-        var solo: Boolean? = null
     )
 
     @Serializable

--- a/src/main/kotlin/io/Svp.kt
+++ b/src/main/kotlin/io/Svp.kt
@@ -5,6 +5,7 @@ import external.generateUUID
 import kotlin.math.roundToLong
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import model.DEFAULT_LYRIC
 import model.ExportNotification
 import model.ExportResult
@@ -277,7 +278,7 @@ object Svp {
         var groups: List<Ref>? = null,
         var mainGroup: Group? = null,
         var mainRef: Ref? = null,
-        var mixer: Mixer? = null,
+        var mixer: JsonElement? = null,
         var name: String? = null,
         var renderEnabled: Boolean? = null
     )
@@ -305,22 +306,13 @@ object Svp {
 
     @Serializable
     private data class Ref(
-        var audio: Audio? = null,
+        var audio: JsonElement? = null,
         var blickOffset: Long = 0,
-        var database: Database? = null,
+        var database: JsonElement? = null,
         var dictionary: String? = null,
         var groupID: String,
         var isInstrumental: Boolean? = null,
         var pitchOffset: Int = 0
-    )
-
-    @Serializable
-    private data class Mixer(
-        var display: Boolean? = null,
-        var gainDecibel: Double? = null,
-        var mute: Boolean? = null,
-        var pan: Double? = null,
-        var solo: Boolean? = null
     )
 
     @Serializable
@@ -335,13 +327,13 @@ object Svp {
 
     @Serializable
     private data class Parameters(
-        var breathiness: Breathiness? = null,
-        var gender: Gender? = null,
-        var loudness: Loudness? = null,
+        var breathiness: JsonElement? = null,
+        var gender: JsonElement? = null,
+        var loudness: JsonElement? = null,
         var pitchDelta: PitchDelta? = null,
-        var tension: Tension? = null,
+        var tension: JsonElement? = null,
         var vibratoEnv: VibratoEnv? = null,
-        var voicing: Voicing? = null
+        var voicing: JsonElement? = null
     )
 
     @Serializable
@@ -355,33 +347,9 @@ object Svp {
     )
 
     @Serializable
-    private data class Breathiness(
-        var mode: String? = null,
-        var points: List<String>? = null
-    )
-
-    @Serializable
-    private data class Gender(
-        var mode: String? = null,
-        var points: List<String>? = null
-    )
-
-    @Serializable
-    private data class Loudness(
-        var mode: String? = null,
-        var points: List<String>? = null
-    )
-
-    @Serializable
     private data class PitchDelta(
         var mode: String? = null,
         var points: List<Double>? = null
-    )
-
-    @Serializable
-    private data class Tension(
-        var mode: String? = null,
-        var points: List<String>? = null
     )
 
     @Serializable
@@ -390,22 +358,4 @@ object Svp {
         var points: List<Double>? = null
     )
 
-    @Serializable
-    private data class Voicing(
-        var mode: String? = null,
-        var points: List<String>? = null
-    )
-
-    @Serializable
-    private data class Audio(
-        var duration: Double? = null,
-        var filename: String? = null
-    )
-
-    @Serializable
-    private data class Database(
-        var language: String? = null,
-        var name: String? = null,
-        var phoneset: String? = null
-    )
 }

--- a/src/main/kotlin/io/Svp.kt
+++ b/src/main/kotlin/io/Svp.kt
@@ -357,5 +357,4 @@ object Svp {
         var mode: String? = null,
         var points: List<Double>? = null
     )
-
 }

--- a/src/main/kotlin/io/Vpr.kt
+++ b/src/main/kotlin/io/Vpr.kt
@@ -6,7 +6,7 @@ import external.Resources
 import kotlinx.coroutines.await
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonElement
 import model.DEFAULT_LYRIC
 import model.ExportNotification
 import model.ExportResult
@@ -233,13 +233,13 @@ object Vpr {
         var samplingRate: Int? = null,
         var tempo: Tempo? = null,
         var timeSig: TimeSig? = null,
-        var volume: MasterVolume? = null
+        var volume: JsonElement? = null
     )
 
     @Serializable
     private data class Tempo(
         var events: List<TempoEvent> = listOf(),
-        var global: Global? = null,
+        var global: JsonElement? = null,
         var height: Double? = null,
         var isFolded: Boolean? = null
     )
@@ -248,12 +248,6 @@ object Vpr {
     private data class TempoEvent(
         var pos: Long,
         var value: Int
-    )
-
-    @Serializable
-    private data class Global(
-        var isEnabled: Boolean? = null,
-        var varue: Int? = null
     )
 
     @Serializable
@@ -270,19 +264,6 @@ object Vpr {
     )
 
     @Serializable
-    private data class MasterVolume(
-        var events: List<MasterVolumeEvent>? = null,
-        var height: Double? = null,
-        var isFolded: Boolean? = null
-    )
-
-    @Serializable
-    private data class MasterVolumeEvent(
-        var pos: Long? = null,
-        var value: Int? = null
-    )
-
-    @Serializable
     private data class Track(
         var busNo: Int? = null,
         var color: Int? = null,
@@ -291,23 +272,10 @@ object Vpr {
         var isMuted: Boolean? = null,
         var isSoloMode: Boolean? = null,
         var name: String? = null,
-        var panpot: Panpot? = null,
+        var panpot: JsonElement? = null,
         var parts: List<Part> = listOf(),
         var type: Int? = null,
-        var volume: Volume? = null
-    )
-
-    @Serializable
-    private data class Panpot(
-        var events: List<PanpotEvent>? = null,
-        var height: Double? = null,
-        var isFolded: Boolean? = null
-    )
-
-    @Serializable
-    private data class PanpotEvent(
-        var pos: Long? = null,
-        var value: Int? = null
+        var volume: JsonElement? = null
     )
 
     @Serializable
@@ -333,11 +301,11 @@ object Vpr {
     @Serializable
     private data class Part(
         var duration: Long = 0L,
-        var midiEffects: List<MidiEffect>? = null,
+        var midiEffects: JsonElement? = null,
         var notes: List<Note> = listOf(),
         var pos: Long,
         var styleName: String? = null,
-        var voice: PartVoice? = null,
+        var voice: JsonElement? = null,
         var controllers: List<Controller>? = null
     ) {
         fun getControllerEvents(name: String) = controllers?.find { it.name == name }?.events.orEmpty()
@@ -356,66 +324,16 @@ object Vpr {
     )
 
     @Serializable
-    private data class MidiEffect(
-        var id: String? = null,
-        var isBypassed: Boolean? = null,
-        var isFolded: Boolean? = null,
-        var parameters: List<JsonObject>? = null
-    )
-
-    @Serializable
     private data class Note(
         var duration: Long = 0L,
-        var exp: Exp? = null,
+        var exp: JsonElement? = null,
         var isProtected: Boolean? = null,
         var lyric: String? = null,
         var number: Int,
         var phoneme: String? = null,
         var pos: Long,
-        var singingSkill: SingingSkill? = null,
+        var singingSkill: JsonElement? = null,
         var velocity: Int? = null,
-        var vibrato: Vibrato? = null
-    )
-
-    @Serializable
-    private data class Exp(
-        var opening: Int? = null
-    )
-
-    @Serializable
-    private data class SingingSkill(
-        var duration: Int? = null,
-        var weight: Weight? = null
-    )
-
-    @Serializable
-    private data class Weight(
-        var post: Int? = null,
-        var pre: Int? = null
-    )
-
-    @Serializable
-    private data class Vibrato(
-        var duration: Int? = null,
-        var type: Int? = null
-    )
-
-    @Serializable
-    private data class PartVoice(
-        var compID: String? = null,
-        var langID: Int? = null
-    )
-
-    @Serializable
-    private data class Volume(
-        var events: List<VolumeEvent>? = null,
-        var height: Double? = null,
-        var isFolded: Boolean? = null
-    )
-
-    @Serializable
-    private data class VolumeEvent(
-        var pos: Int? = null,
-        var value: Int? = null
+        var vibrato: JsonElement? = null
     )
 }


### PR DESCRIPTION
- Use `JsonElement` for all the properties that will not be used to improve compatibility among different project versions
- Fix time variables using `Long` instead of `Int`