### PR TITLE
Fix issues in MusicXml import

### DIFF
--- a/src/main/kotlin/io/MusicXml.kt
+++ b/src/main/kotlin/io/MusicXml.kt
@@ -132,9 +132,13 @@ object MusicXml {
         partNode.getElementListByTagName("measure").forEachIndexed { index, measureNode ->
             var tickPosition = masterTrackResult.measureBorders[index]
             measureNode.getElementListByTagName("note").forEach { noteNode ->
-                val duration =
-                    (noteNode.getSingleElementByTagName("duration")
-                        .innerValue.toLong() * importTickRate).toLong()
+                val duration = noteNode.getSingleElementByTagNameOrNull("duration")
+                    ?.innerValue?.toLongOrNull()?.times(importTickRate)?.toLong()
+                    ?: if (noteNode.getSingleElementByTagNameOrNull("grace") != null) {
+                        return@forEach
+                    } else {
+                        throw IllegalFileException.XmlElementNotFound("duration")
+                    }
                 if (noteNode.getElementListByTagName("rest").isNotEmpty()) {
                     tickPosition += duration
                     return@forEach

--- a/src/main/kotlin/io/MusicXml.kt
+++ b/src/main/kotlin/io/MusicXml.kt
@@ -96,7 +96,7 @@ object MusicXml {
                 ?: currentTimeSignature
 
             measureNode.getElementListByTagName("sound")
-                .firstOrNull()
+                .firstOrNull { it.hasAttribute("tempo") }
                 ?.let { soundNode ->
                     Tempo(
                         tickPosition = tickPosition,


### PR DESCRIPTION
1. A `<sound>` element may have no `"tempo"` attribute; Ignore it then
2. A `<note>` element may have no `<duration>` child, instead, with a `<grace>` child. In this case, the note is a grace note which does not occupy time duration; Ignore the note.