### PR TITLE
Change default extension of MusicXml to .musicxml

### DIFF
--- a/src/main/kotlin/model/Format.kt
+++ b/src/main/kotlin/model/Format.kt
@@ -84,8 +84,8 @@ enum class Format(
         availableFeaturesForGeneration = listOf(ConvertPitch)
     ),
     MusicXml(
-        ".xml",
-        otherExtensions = listOf(".musicxml"),
+        ".musicxml",
+        otherExtensions = listOf(".xml"),
         parser = {
             io.MusicXml.parse(it.first())
         },


### PR DESCRIPTION
The main usage of MusicXml export is for NEUTRINO usage which in default reads ".musicxml".