### PR TITLE
Revert to use jcenter() repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,7 @@ group = "com.sdercolin.utaformatix"
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://kotlin.bintray.com/kotlin-js-wrappers/") }
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx/") }
+    jcenter()
 }
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {


### PR DESCRIPTION
Unknown reason but suddenly get errors
```
 > Could not resolve org.jetbrains:kotlin-react:17.0.1-pre.148-kotlin-1.4.21.
     Required by:
         project :
      > Could not resolve org.jetbrains:kotlin-react:17.0.1-pre.148-kotlin-1.4.21.
         > Could not get resource 'https://kotlin.bintray.com/kotlin-js-wrappers/org/jetbrains/kotlin-react/17.0.1-pre.148-kotlin-1.4.21/kotlin-react-17.0.1-pre.148-kotlin-1.4.21.pom'.
            > Could not GET 'https://kotlin.bintray.com/kotlin-js-wrappers/org/jetbrains/kotlin-react/17.0.1-pre.148-kotlin-1.4.21/kotlin-react-17.0.1-pre.148-kotlin-1.4.21.pom'. Received status code 403 from server: Forbidden
      > Could not resolve org.jetbrains:kotlin-react:17.0.1-pre.148-kotlin-1.4.21.
         > Could not get resource 'https://dl.bintray.com/kotlin/kotlinx/org/jetbrains/kotlin-react/17.0.1-pre.148-kotlin-1.4.21/kotlin-react-17.0.1-pre.148-kotlin-1.4.21.pom'.
            > Could not GET 'https://dl.bintray.com/kotlin/kotlinx/org/jetbrains/kotlin-react/17.0.1-pre.148-kotlin-1.4.21/kotlin-react-17.0.1-pre.148-kotlin-1.4.21.pom'. Received status code 403 from server: Forbidden
```