### PR TITLE
Save pitch to mode1 ust

### DIFF
--- a/src/main/kotlin/io/Ust.kt
+++ b/src/main/kotlin/io/Ust.kt
@@ -301,12 +301,14 @@ object Ust {
         builder.appendLine("Tempo=$bpm")
         builder.appendLine("Tracks=1")
         builder.appendLine("ProjectName=${track.name}")
-        //TODO:Mode2 output
+        // TODO: Mode2 output
         if (!features.contains(Feature.ConvertPitch))
             builder.appendLine("Mode2=True")
         var tickPos = 0L
         var restCount = 0
-        val pitchData = if (features.contains(Feature.ConvertPitch)) pitchToUtauMode1Track(track.pitch, track.notes) else null
+        val pitchData = if (features.contains(Feature.ConvertPitch)) {
+            pitchToUtauMode1Track(track.pitch, track.notes)
+        } else null
         for ((index, note) in track.notes.withIndex()) {
             if (tickPos < note.tickOn) {
                 val restNoteNumber = (note.id + restCount).padStartZero(4)
@@ -324,10 +326,10 @@ object Ust {
             builder.appendLine("NoteNum=${note.key}")
             builder.appendLine("PreUtterance=")
 
-            if (features.contains(Feature.ConvertPitch)){
+            if (features.contains(Feature.ConvertPitch)) {
                 builder.appendLine("PBType=5")
                 val pitchString = makeMode1PitchDataString(pitchData?.notes?.get(index))
-                builder.appendLine("PitchBend=${pitchString}")
+                builder.appendLine("PitchBend=$pitchString")
                 builder.appendLine("PBStart=0")
             }
 
@@ -343,7 +345,7 @@ object Ust {
         return substring(index + 1).takeIf { it.isNotBlank() }
     }
 
-    private fun makeMode1PitchDataString(notePitch : UtauMode1NotePitchData?): String?{
+    private fun makeMode1PitchDataString(notePitch: UtauMode1NotePitchData?): String? {
         return notePitch?.pitchPoints?.joinToString(separator = ",") { it.toInt().toString() }
     }
 

--- a/src/main/kotlin/model/Format.kt
+++ b/src/main/kotlin/model/Format.kt
@@ -45,10 +45,11 @@ enum class Format(
         parser = {
             io.Ust.parse(it)
         },
-        generator = { project, _ ->
-            io.Ust.generate(project)
+        generator = { project, features ->
+            io.Ust.generate(project, features)
         },
-        possibleLyricsTypes = listOf(RomajiCv, RomajiVcv, KanaCv, KanaVcv)
+        possibleLyricsTypes = listOf(RomajiCv, RomajiVcv, KanaCv, KanaVcv),
+        availableFeaturesForGeneration = listOf(ConvertPitch)
     ),
     Ccs(
         ".ccs",

--- a/src/main/kotlin/process/Resample.kt
+++ b/src/main/kotlin/process/Resample.kt
@@ -15,5 +15,5 @@ fun List<Pair<Long, Double?>>.resampled(sampleRate : Long,
         return result
     }
 
-/// A shorthand for pitch represented in dot. Its interpolateMethod simply copy the value from prev.
-fun Pitch.dotResampled(sampleRate: Long) = Pitch(data.resampled(sampleRate) { prev, _, _ -> prev?.second }, isAbsolute)
+/// A shorthand for pitch represented in dot. Its interpolateMethod simply copy the value from prev, or next if prev not exists, or 0.0 if neither of them exists.
+fun Pitch.dotResampled(sampleRate: Long) = Pitch(data.resampled(sampleRate) { prev, next, _ -> prev?.second ?: next?.second ?: 0.0 }, isAbsolute)

--- a/src/main/kotlin/process/Resample.kt
+++ b/src/main/kotlin/process/Resample.kt
@@ -1,27 +1,26 @@
 package process
 
-import model.Pitch
-
 fun List<Pair<Long, Double?>>.resampled(
-    sampleRate: Long,
+    interval: Long,
     interpolateMethod: (
         prev: Pair<Long, Double?>?,
         next: Pair<Long, Double?>?,
         pos: Long
     ) -> Double?
-): MutableList<Pair<Long, Double?>> {
+): List<Pair<Long, Double?>> {
     val result: MutableList<Pair<Long, Double?>> = mutableListOf()
-    val length = this.map { it.first }.maxOrNull() ?: 0
-    for (current in 0..length step sampleRate) {
+    val leftBound = this.map { it.first }.minOrNull() ?: 0
+    val rightBound = this.map { it.first }.maxOrNull() ?: 0
+    for (current in leftBound..rightBound step interval) {
         val prev = this.lastOrNull { it.first <= current }
         val next = this.firstOrNull { it.first >= current }
         result.add(Pair(current, interpolateMethod(prev, next, current)))
     }
-    return result
+    return result.toList()
 }
 
 // A shorthand for pitch represented in dot.
 // Its interpolateMethod simply copy the value from prev, or next if prev not exists, or 0.0 if neither of them exists.
-fun Pitch.dotResampled(sampleRate: Long) = Pitch(data.resampled(sampleRate) { prev, next, _ ->
+fun List<Pair<Long, Double?>>.dotResampled(interval: Long) = resampled(interval) { prev, next, _ ->
     prev?.second ?: next?.second ?: 0.0
-}, isAbsolute)
+}

--- a/src/main/kotlin/process/Resample.kt
+++ b/src/main/kotlin/process/Resample.kt
@@ -1,0 +1,19 @@
+package process
+
+import model.Pitch
+
+fun List<Pair<Long, Double?>>.resampled(sampleRate : Long,
+                                      interpolateMethod: (prev: Pair<Long, Double?>?, next: Pair<Long, Double?>?,
+                                                          pos: Long) -> Double?): MutableList<Pair<Long, Double?>> {
+        val result: MutableList<Pair<Long, Double?>> = mutableListOf()
+        val length = this.map { it.first }.maxOrNull() ?: 0
+        for (current in 0..length step sampleRate){
+            val prev = this.lastOrNull{it.first <= current}
+            val next = this.firstOrNull{it.first >= current}
+            result.add(Pair(current, interpolateMethod(prev, next, current)))
+        }
+        return result
+    }
+
+/// A shorthand for pitch represented in dot. Its interpolateMethod simply copy the value from prev.
+fun Pitch.dotResampled(sampleRate: Long) = Pitch(data.resampled(sampleRate) { prev, _, _ -> prev?.second }, isAbsolute)

--- a/src/main/kotlin/process/Resample.kt
+++ b/src/main/kotlin/process/Resample.kt
@@ -2,18 +2,26 @@ package process
 
 import model.Pitch
 
-fun List<Pair<Long, Double?>>.resampled(sampleRate : Long,
-                                      interpolateMethod: (prev: Pair<Long, Double?>?, next: Pair<Long, Double?>?,
-                                                          pos: Long) -> Double?): MutableList<Pair<Long, Double?>> {
-        val result: MutableList<Pair<Long, Double?>> = mutableListOf()
-        val length = this.map { it.first }.maxOrNull() ?: 0
-        for (current in 0..length step sampleRate){
-            val prev = this.lastOrNull{it.first <= current}
-            val next = this.firstOrNull{it.first >= current}
-            result.add(Pair(current, interpolateMethod(prev, next, current)))
-        }
-        return result
+fun List<Pair<Long, Double?>>.resampled(
+    sampleRate: Long,
+    interpolateMethod: (
+        prev: Pair<Long, Double?>?,
+        next: Pair<Long, Double?>?,
+        pos: Long
+    ) -> Double?
+): MutableList<Pair<Long, Double?>> {
+    val result: MutableList<Pair<Long, Double?>> = mutableListOf()
+    val length = this.map { it.first }.maxOrNull() ?: 0
+    for (current in 0..length step sampleRate) {
+        val prev = this.lastOrNull { it.first <= current }
+        val next = this.firstOrNull { it.first >= current }
+        result.add(Pair(current, interpolateMethod(prev, next, current)))
     }
+    return result
+}
 
-/// A shorthand for pitch represented in dot. Its interpolateMethod simply copy the value from prev, or next if prev not exists, or 0.0 if neither of them exists.
-fun Pitch.dotResampled(sampleRate: Long) = Pitch(data.resampled(sampleRate) { prev, next, _ -> prev?.second ?: next?.second ?: 0.0 }, isAbsolute)
+// A shorthand for pitch represented in dot.
+// Its interpolateMethod simply copy the value from prev, or next if prev not exists, or 0.0 if neither of them exists.
+fun Pitch.dotResampled(sampleRate: Long) = Pitch(data.resampled(sampleRate) { prev, next, _ ->
+    prev?.second ?: next?.second ?: 0.0
+}, isAbsolute)

--- a/src/main/kotlin/process/Resample.kt
+++ b/src/main/kotlin/process/Resample.kt
@@ -20,7 +20,7 @@ fun List<Pair<Long, Double?>>.resampled(
 }
 
 // A shorthand for pitch represented in dot.
-// Its interpolateMethod simply copy the value from prev, or next if prev not exists, or 0.0 if neither of them exists.
+// Its interpolateMethod simply copy the value from prev, or next if prev not exists.
 fun List<Pair<Long, Double?>>.dotResampled(interval: Long) = resampled(interval) { prev, next, _ ->
-    prev?.second ?: next?.second ?: 0.0
+    prev?.second ?: next?.second
 }

--- a/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
@@ -48,17 +48,11 @@ fun pitchToUtauMode1Track(pitch: Pitch?, notes: List<Note>): UtauMode1TrackPitch
         console.log(note)
         UtauMode1NotePitchData(
             pitch
-                //.apply { console.log("raw = \n");console.log(this) }
                 .getAbsoluteData(notes)
-                //.apply { console.log("absolute = \n");console.log(this) }
-                ?.filter { it.second != null }
                 ?.filter { it.first >= note.tickOn && it.first < note.tickOff }
-                //.apply { console.log("filtered = \n");console.log(this) }
                 ?.dotResampled(Ust.MODE1_PITCH_SAMPLING_INTERVAL_TICK)
-                //.apply { console.log("resampled = \n");console.log(this) }
                 ?.map { Pair(it.first, it.second ?: note.key.toDouble()) }
                 ?.map { (it.second - note.key) * 100 }
-                //.apply { console.log("final = \n");console.log(this) }
         )
     })
 }

--- a/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
@@ -3,6 +3,7 @@ package process.pitch
 import io.Ust
 import model.Note
 import model.Pitch
+import process.dotResampled
 
 data class UtauMode1TrackPitchData(
     val notes: List<UtauMode1NotePitchData?>
@@ -39,4 +40,16 @@ fun pitchFromUtauMode1Track(pitchData: UtauMode1TrackPitchData?, notes: List<Not
         }
     }
     return Pitch(pitchPoints, false).getAbsoluteData(notes)?.let { Pitch(it, true) }
+}
+const val SEMITONE_TO_CENT_RATIO = 100;
+fun pitchToUtauMode1Track(pitch: Pitch?, notes: List<Note>): UtauMode1TrackPitchData? {
+    pitch ?: return null
+    val pitchResampled = pitch.dotResampled(Ust.MODE1_PITCH_SAMPLING_INTERVAL_TICK)
+    console.log(pitchResampled.getRelativeData(notes))
+    return UtauMode1TrackPitchData(notes.map{ note ->
+        UtauMode1NotePitchData(pitchResampled
+            .getRelativeData(notes)
+            ?.filter { it.first >= note.tickOn && it.first <= note.tickOff}
+            ?.map { it.second * SEMITONE_TO_CENT_RATIO})
+    })
 }

--- a/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
@@ -41,15 +41,15 @@ fun pitchFromUtauMode1Track(pitchData: UtauMode1TrackPitchData?, notes: List<Not
     }
     return Pitch(pitchPoints, false).getAbsoluteData(notes)?.let { Pitch(it, true) }
 }
-const val SEMITONE_TO_CENT_RATIO = 100;
+const val SEMITONE_TO_CENT_RATIO = 100
 fun pitchToUtauMode1Track(pitch: Pitch?, notes: List<Note>): UtauMode1TrackPitchData? {
     pitch ?: return null
     val pitchResampled = pitch.dotResampled(Ust.MODE1_PITCH_SAMPLING_INTERVAL_TICK)
     console.log(pitchResampled.getRelativeData(notes))
-    return UtauMode1TrackPitchData(notes.map{ note ->
+    return UtauMode1TrackPitchData(notes.map { note ->
         UtauMode1NotePitchData(pitchResampled
             .getRelativeData(notes)
-            ?.filter { it.first >= note.tickOn && it.first <= note.tickOff}
-            ?.map { it.second * SEMITONE_TO_CENT_RATIO})
+            ?.filter { it.first >= note.tickOn && it.first <= note.tickOff }
+            ?.map { it.second * SEMITONE_TO_CENT_RATIO })
     })
 }

--- a/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
@@ -41,15 +41,18 @@ fun pitchFromUtauMode1Track(pitchData: UtauMode1TrackPitchData?, notes: List<Not
     }
     return Pitch(pitchPoints, false).getAbsoluteData(notes)?.let { Pitch(it, true) }
 }
-const val SEMITONE_TO_CENT_RATIO = 100
+
 fun pitchToUtauMode1Track(pitch: Pitch?, notes: List<Note>): UtauMode1TrackPitchData? {
     pitch ?: return null
-    val pitchResampled = pitch.dotResampled(Ust.MODE1_PITCH_SAMPLING_INTERVAL_TICK)
-    console.log(pitchResampled.getRelativeData(notes))
     return UtauMode1TrackPitchData(notes.map { note ->
-        UtauMode1NotePitchData(pitchResampled
-            .getRelativeData(notes)
-            ?.filter { it.first >= note.tickOn && it.first <= note.tickOff }
-            ?.map { it.second * SEMITONE_TO_CENT_RATIO })
+        UtauMode1NotePitchData(
+            pitch
+                .getAbsoluteData(notes)
+                ?.filter { it.second != null }
+                ?.filter { it.first >= note.tickOn && it.first < note.tickOff }
+                ?.dotResampled(Ust.MODE1_PITCH_SAMPLING_INTERVAL_TICK)?.let { absoluteData ->
+                    Pitch(absoluteData, isAbsolute = true).getRelativeData(notes)?.map { it.second * 100 }
+                }
+        )
     })
 }

--- a/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode1PitchConversion.kt
@@ -45,14 +45,20 @@ fun pitchFromUtauMode1Track(pitchData: UtauMode1TrackPitchData?, notes: List<Not
 fun pitchToUtauMode1Track(pitch: Pitch?, notes: List<Note>): UtauMode1TrackPitchData? {
     pitch ?: return null
     return UtauMode1TrackPitchData(notes.map { note ->
+        console.log(note)
         UtauMode1NotePitchData(
             pitch
+                //.apply { console.log("raw = \n");console.log(this) }
                 .getAbsoluteData(notes)
+                //.apply { console.log("absolute = \n");console.log(this) }
                 ?.filter { it.second != null }
                 ?.filter { it.first >= note.tickOn && it.first < note.tickOff }
-                ?.dotResampled(Ust.MODE1_PITCH_SAMPLING_INTERVAL_TICK)?.let { absoluteData ->
-                    Pitch(absoluteData, isAbsolute = true).getRelativeData(notes)?.map { it.second * 100 }
-                }
+                //.apply { console.log("filtered = \n");console.log(this) }
+                ?.dotResampled(Ust.MODE1_PITCH_SAMPLING_INTERVAL_TICK)
+                //.apply { console.log("resampled = \n");console.log(this) }
+                ?.map { Pair(it.first, it.second ?: note.key.toDouble()) }
+                ?.map { (it.second - note.key) * 100 }
+                //.apply { console.log("final = \n");console.log(this) }
         )
     })
 }


### PR DESCRIPTION
As the feature describe in branch name is done, I think it's a good time to ask for a review and PR.

In this pr, ust format's pitch save feature is implemented to save in UTAU's mode1 pitchbend, which save pitch relatively in cents by every 5 ticks. A resample extension function is used to resample pitch data to meet the requirment.