### PR TITLE
Read note parameters about pitch from Dv file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The current version `3.x` is built with [Kotlin for JavaScript](https://kotlinla
   |         CCS          |       ✓      |                |       ✓      |
   |         SVP          |       ✓      |        ✓       |       ✓      |
   |         S5P          |       ✓      |                |       ✓      |
-  |         DV           |       ✓      |                |       ✓      |
+  |         DV           |       ✓      |        ✓       |       ✓      |
   
 ## Contributors
 

--- a/src/main/kotlin/io/Dv.kt
+++ b/src/main/kotlin/io/Dv.kt
@@ -113,7 +113,7 @@ object Dv {
                 val lyric = reader.readString()
                 reader.readString() // lyric in Chinese character
                 reader.skip(1)
-                reader.readBytes()
+                val vibratoData = parseNoteVibratoData(reader)
                 reader.readBytes()
                 reader.skip(18)
                 val benDep = reader.readInt()
@@ -137,7 +137,7 @@ object Dv {
                         benLen = benLen,
                         porHead = porHead,
                         porTail = porTail,
-                        vibrato = listOf()
+                        vibrato = vibratoData
                     )
                 )
             }
@@ -152,6 +152,19 @@ object Dv {
             notes = notesWithPitchValidated.map { it.note },
             pitch = pitchFromDvTrack(segmentPitchDataList, notesWithPitchValidated, tempos)
         )
+    }
+
+    private fun parseNoteVibratoData(reader: ArrayBufferReader): List<Pair<Int, Int>> {
+        reader.readInt() // vibrato block size
+        reader.readBytes()
+        reader.readBytes()
+        reader.readInt() // rendered-vibrato block size
+        val pointLength = reader.readInt()
+        val data = mutableListOf<Pair<Int, Int>>()
+        repeat(pointLength) {
+            data.add(reader.readInt() to reader.readInt())
+        }
+        return data
     }
 
     private fun parsePitchData(tickOffset: Long, reader: ArrayBufferReader): DvSegmentPitchRawData {

--- a/src/main/kotlin/io/Dv.kt
+++ b/src/main/kotlin/io/Dv.kt
@@ -15,9 +15,10 @@ import org.khronos.webgl.Uint8Array
 import org.w3c.files.Blob
 import org.w3c.files.BlobPropertyBag
 import org.w3c.files.File
-import process.pitch.DvSegmentPitchData
+import process.pitch.DvNoteWithPitch
+import process.pitch.DvSegmentPitchRawData
 import process.pitch.generateForDv
-import process.pitch.pitchFromDvSegments
+import process.pitch.pitchFromDvTrack
 import process.validateNotes
 import util.ArrayBufferReader
 import util.addBlock
@@ -67,7 +68,7 @@ object Dv {
         val trackCount = reader.readInt()
         var tracks = mutableListOf<Track>()
         repeat(trackCount) {
-            parseTrack(tickPrefix, reader)?.let { track ->
+            parseTrack(tickPrefix, tempos, reader)?.let { track ->
                 tracks.add(track.validateNotes())
             }
         }
@@ -85,7 +86,7 @@ object Dv {
         )
     }
 
-    private fun parseTrack(tickPrefix: Long, reader: ArrayBufferReader): Track? {
+    private fun parseTrack(tickPrefix: Long, tempos: List<Tempo>, reader: ArrayBufferReader): Track? {
         val trackType = reader.readInt()
         if (trackType != 0) {
             skipRestOfInstTrack(reader)
@@ -94,9 +95,9 @@ object Dv {
         val trackName = reader.readString()
         reader.skip(14)
 
-        val notes = mutableListOf<Note>()
+        val notesWithPitch = mutableListOf<DvNoteWithPitch>()
         val segmentCount = reader.readInt()
-        val segmentPitchDataList = mutableListOf<DvSegmentPitchData>()
+        val segmentPitchDataList = mutableListOf<DvSegmentPitchRawData>()
         repeat(segmentCount) {
             val segmentStart = reader.readInt()
             reader.readInt() // segment length
@@ -111,14 +112,32 @@ object Dv {
                 reader.skip(4)
                 val lyric = reader.readString()
                 reader.readString() // lyric in Chinese character
-                skipRestOfNote(reader)
-                notes.add(
-                    Note(
-                        id = 0,
-                        key = noteKey,
-                        lyric = lyric,
-                        tickOn = segmentStart + noteStart - tickPrefix,
-                        tickOff = segmentStart + noteStart - tickPrefix + noteLength
+                reader.skip(1)
+                reader.readBytes()
+                reader.readBytes()
+                reader.skip(18)
+                val benDep = reader.readInt()
+                val benLen = reader.readInt()
+                val porTail = reader.readInt()
+                val porHead = reader.readInt()
+                reader.readInt()
+                reader.readBytes()
+                reader.readInt()
+                val note = Note(
+                    id = 0,
+                    key = noteKey,
+                    lyric = lyric,
+                    tickOn = segmentStart + noteStart - tickPrefix,
+                    tickOff = segmentStart + noteStart - tickPrefix + noteLength
+                )
+                notesWithPitch.add(
+                    DvNoteWithPitch(
+                        note = note,
+                        benDep = benDep,
+                        benLen = benLen,
+                        porHead = porHead,
+                        porTail = porTail,
+                        vibrato = listOf()
                     )
                 )
             }
@@ -126,22 +145,23 @@ object Dv {
             segmentPitchDataList.add(parsePitchData(segmentStart - tickPrefix, reader))
             skipRestOfSegment(reader)
         }
+        val notesWithPitchValidated = notesWithPitch.validateNotes()
         return Track(
             id = 0,
             name = trackName,
-            notes = notes,
-            pitch = pitchFromDvSegments(segmentPitchDataList)
+            notes = notesWithPitchValidated.map { it.note },
+            pitch = pitchFromDvTrack(segmentPitchDataList, notesWithPitchValidated, tempos)
         )
     }
 
-    private fun parsePitchData(tickOffset: Long, reader: ArrayBufferReader): DvSegmentPitchData {
+    private fun parsePitchData(tickOffset: Long, reader: ArrayBufferReader): DvSegmentPitchRawData {
         reader.readInt()
         val pointLength = reader.readInt()
         val data = mutableListOf<Pair<Int, Int>>()
         repeat(pointLength) {
             data.add(reader.readInt() to reader.readInt())
         }
-        return DvSegmentPitchData(tickOffset, data)
+        return DvSegmentPitchRawData(tickOffset, data)
     }
 
     private fun skipRestOfInstTrack(reader: ArrayBufferReader) {
@@ -158,15 +178,6 @@ object Dv {
         repeat(5) {
             reader.readBytes()
         }
-    }
-
-    private fun skipRestOfNote(reader: ArrayBufferReader) {
-        reader.skip(1)
-        reader.readBytes()
-        reader.readBytes()
-        reader.skip(38)
-        reader.readBytes()
-        reader.skip(4)
     }
 
     private fun getTickPrefix(timeSignatures: List<TimeSignature>): Long {

--- a/src/main/kotlin/model/Note.kt
+++ b/src/main/kotlin/model/Note.kt
@@ -1,5 +1,7 @@
 package model
 
+import process.RichNote
+
 data class Note(
     val id: Int,
     val key: Int,
@@ -7,6 +9,11 @@ data class Note(
     val tickOn: Long,
     val tickOff: Long,
     val xSampa: String? = null
-) {
+) : RichNote<Note> {
     val length get() = tickOff - tickOn
+
+    override val note: Note
+        get() = this
+
+    override fun copyWithNote(note: Note) = note
 }

--- a/src/main/kotlin/process/TickTimeTransformation.kt
+++ b/src/main/kotlin/process/TickTimeTransformation.kt
@@ -1,0 +1,41 @@
+package process
+
+import model.TICKS_IN_BEAT
+import model.Tempo
+
+fun Double.bpmToSecPerTick() = 60.0 / TICKS_IN_BEAT / this
+
+class TickTimeTransformer(
+    tempos: List<Tempo>
+) {
+    private class Segment(
+        val range: LongRange,
+        val offset: Double,
+        val secPerTick: Double
+    )
+
+    // a piecewise linear transformation from tick to sec
+    // simplify the calculation here for every usage to reduce cost
+    private val segments = (tempos.zipWithNext() + (tempos.last() to null))
+        .fold(listOf<Segment>()) { acc, (thisTempo, nextTempo) ->
+            val range = thisTempo.tickPosition until (nextTempo?.tickPosition ?: Long.MAX_VALUE)
+            val rate = thisTempo.bpm.bpmToSecPerTick()
+            val thisResult = if (acc.isEmpty()) {
+                Segment(range, 0.0, rate)
+            } else {
+                val lastParams = acc.last()
+                val offset = lastParams.offset +
+                        (lastParams.range.last - lastParams.range.first) * lastParams.secPerTick
+                Segment(range, offset, rate)
+            }
+            acc + thisResult
+        }
+
+    fun tickToSec(tick: Long) = segments
+        .first { tick in it.range }
+        .let { it.offset + (tick - it.range.first) * it.secPerTick }
+
+    fun secToTick(sec: Double) = segments
+        .last { it.offset <= sec }
+        .let { ((sec - it.offset) / it.secPerTick).toLong() + it.range.first }
+}

--- a/src/main/kotlin/process/pitch/DeepVocalPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/DeepVocalPitchConversion.kt
@@ -214,7 +214,6 @@ private fun getVibratoPitch(
         .interpolateLinear(1L)
         .orEmpty()
         .also { console.log(it) }
-
 }.mergeSameTickPoints().orEmpty().toMap()
 
 private val Note.tickHalfStart: Long get() = tickOn + (length + 1) / 2

--- a/src/main/kotlin/process/pitch/DeepVocalPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/DeepVocalPitchConversion.kt
@@ -4,19 +4,47 @@ import io.Dv
 import kotlin.math.roundToInt
 import model.Note
 import model.Pitch
+import model.Tempo
+import process.RichNote
+import process.TickTimeTransformer
+import process.interpolateCosineEaseInOut
+import process.interpolateLinear
 
-data class DvSegmentPitchData(
-    val tickOffset: Long,
+private const val SAMPLING_INTERVAL_TICK = 4L
+private const val PORTAMENTO_LENGTH_MAX_SEC = 0.3125 // [porHead, porTail] == 100
+private const val BEND_DOWN_LENGTH_FIXED_SEC = 0.09375
+private const val BEND_LENGTH_MIN_SEC = 0.375 // benLen <= 50
+private const val BEND_LENGTH_MAX_SEC = 0.6875 // benLen == 100
+private const val BEND_VALUE_MAX = 3.0 // benDep == 100
+
+data class DvSegmentPitchRawData(
+    val tickOffset: Long, // only for import
     val data: List<Pair<Int, Int>>
 )
 
-fun pitchFromDvSegments(dataBySegments: List<DvSegmentPitchData>) = dataBySegments
+data class DvNoteWithPitch(
+    override val note: Note,
+    val porHead: Int, // 0~100
+    val porTail: Int, // 0~100
+    val benLen: Int, // 0~100
+    val benDep: Int, // 0~100
+    val vibrato: List<Pair<Long, Int>> // (ms, DV standard cent)
+) : RichNote<DvNoteWithPitch> {
+    override fun copyWithNote(note: Note) = copy(note = note)
+}
+
+fun pitchFromDvTrack(
+    segments: List<DvSegmentPitchRawData>,
+    notes: List<DvNoteWithPitch>,
+    tempos: List<Tempo>
+) = segments
     .mergePointsFromSegments()
     .mergeSameTickPoints()
     ?.mergeSameValuePoints()
+    ?.applyDefaultPitch(notes, tempos)
     ?.let { Pitch(data = it, isAbsolute = true) }
 
-private fun List<DvSegmentPitchData>.mergePointsFromSegments() = flatMap { segment ->
+private fun List<DvSegmentPitchRawData>.mergePointsFromSegments() = flatMap { segment ->
     segment.data
         .asSequence()
         .mapNotNull { list ->
@@ -48,12 +76,128 @@ private fun List<Pair<Long, Double?>>.mergeSameTickPoints() = asSequence()
     .takeIf { points -> points.any { it.second != null } }
 
 private fun List<Pair<Long, Double?>>.mergeSameValuePoints() = asSequence()
+    .sortedBy { it.first }
     .fold(listOf<Pair<Long, Double?>>()) { acc, point ->
         val lastValue = acc.lastOrNull()?.second
         if (point.second != lastValue) acc + point else acc
     }
 
-fun Pitch.generateForDv(notes: List<Note>): DvSegmentPitchData? {
+private fun List<Pair<Long, Double?>>.applyDefaultPitch(
+    notes: List<DvNoteWithPitch>,
+    tempos: List<Tempo>
+): List<Pair<Long, Double?>> {
+    if (this.isEmpty()) return this
+    if (notes.isEmpty()) return this
+
+    val transformer = TickTimeTransformer(tempos)
+
+    val base = getBasePitch(notes, transformer)
+
+    val bendDiff = getBendPitch(notes, transformer)
+
+    val appendingLastPoint = if (last().first < notes.last().note.tickOff) {
+        notes.last().note.tickOff to null
+    } else null
+
+    return (this + appendingLastPoint).filterNotNull()
+        .fold(listOf()) { acc, point ->
+            val lastPoint = acc.lastOrNull()
+            val startTick = lastPoint?.first ?: 0
+            val endTick = point.first
+
+            if (lastPoint?.second == null) {
+                val interpolatedPoints = (startTick until endTick step SAMPLING_INTERVAL_TICK)
+                    .map { it to (requireNotNull(base[it]) + (bendDiff[it] ?: 0.0)) }
+                acc + interpolatedPoints + point
+            } else {
+                acc + point
+            }
+        }
+}
+
+private fun getBasePitch(
+    notes: List<DvNoteWithPitch>,
+    transformer: TickTimeTransformer
+) = (listOf(null) + notes + listOf(null)).zipWithNext().flatMap { (lastNote, thisNote) ->
+    val result = mutableListOf<Pair<Long, Double>>()
+
+    val portamento = if (lastNote != null && thisNote != null) {
+        getPortamento(lastNote, transformer, thisNote)
+    } else emptyList()
+    result.addAll(portamento)
+
+    if (lastNote != null) {
+        val lastNoteTail = (lastNote.note.tickHalfStart until
+                (portamento.firstOrNull()?.first ?: lastNote.note.tickOff))
+            .map { it to lastNote.note.key.toDouble() }
+        result.addAll(lastNoteTail)
+    }
+
+    if (thisNote != null) {
+        val start = if (lastNote == null) 0 else portamento.lastOrNull()?.first ?: thisNote.note.tickOn
+        val thisNoteHead = (start until thisNote.note.tickHalfStart)
+            .map { it to thisNote.note.key.toDouble() }
+        result.addAll(thisNoteHead)
+    }
+
+    result
+}.mergeSameTickPoints().let { requireNotNull(it) }.toMap()
+
+private fun getBendPitch(
+    notes: List<DvNoteWithPitch>,
+    transformer: TickTimeTransformer
+) = notes.flatMap { note ->
+    val startTick = note.note.tickOn
+    val startSec = transformer.tickToSec(startTick)
+    val valleySec = startSec + BEND_DOWN_LENGTH_FIXED_SEC
+    val valleyTick = transformer.secToTick(valleySec)
+        .coerceAtMost(note.note.tickOn + note.note.length / 2 - 1)
+
+    val lengthSec = if (note.benLen <= 50) {
+        BEND_LENGTH_MIN_SEC
+    } else {
+        (BEND_LENGTH_MAX_SEC - BEND_LENGTH_MIN_SEC) * (note.benLen - 50) / 50 + BEND_LENGTH_MIN_SEC
+    }
+    val endSec = startSec + lengthSec
+    val endTick = transformer.secToTick(endSec)
+        .coerceAtMost(note.note.tickOff - 1)
+
+    val valleyValue = -BEND_VALUE_MAX * note.benDep / 100
+    val valleyPoint = valleyTick to valleyValue
+
+    val bendDown = listOf(startTick to 0.0, valleyPoint)
+        .interpolateLinear(1L)
+        .orEmpty()
+
+    val bendUp = listOf(valleyPoint, endTick to 0.0)
+        .interpolateCosineEaseInOut(1L)
+        .orEmpty()
+        .drop(1)
+
+    bendDown + bendUp
+}.mergeSameTickPoints().let { requireNotNull(it) }.toMap()
+
+private fun getPortamento(
+    lastNote: DvNoteWithPitch,
+    transformer: TickTimeTransformer,
+    thisNote: DvNoteWithPitch
+): List<Pair<Long, Double>> {
+    val tailLengthSec = PORTAMENTO_LENGTH_MAX_SEC * lastNote.porTail / 100
+    val startSec = transformer.tickToSec(lastNote.note.tickOff) - tailLengthSec
+    val startTick = transformer.secToTick(startSec).coerceAtLeast(lastNote.note.tickHalfStart)
+
+    val headLengthSec = PORTAMENTO_LENGTH_MAX_SEC * thisNote.porHead / 100
+    val endSec = transformer.tickToSec(thisNote.note.tickOn) + headLengthSec
+    val endTick = transformer.secToTick(endSec).coerceAtMost(thisNote.note.tickHalfStart - 1)
+
+    return listOf(startTick to lastNote.note.key.toDouble(), endTick to thisNote.note.key.toDouble())
+        .interpolateCosineEaseInOut(1L)
+        .orEmpty()
+}
+
+private val Note.tickHalfStart: Long get() = tickOn + (length + 1) / 2
+
+fun Pitch.generateForDv(notes: List<Note>): DvSegmentPitchRawData? {
     if (notes.isEmpty()) return null
     val points: List<Pair<Long, Double?>> = getAbsoluteData(notes)
         ?.takeIf { it.isNotEmpty() }
@@ -65,7 +209,7 @@ fun Pitch.generateForDv(notes: List<Note>): DvSegmentPitchData? {
             it.first.toInt() to rawValue
         }
 
-    return DvSegmentPitchData(0L, data)
+    return DvSegmentPitchRawData(0L, data)
 }
 
 private fun List<Pair<Long, Double?>>.appendPoints(): List<Pair<Long, Double?>> {


### PR DESCRIPTION
## New
- `TickTimeTransformer`: Extracted from synth-v process to handle transformation between tick and time(second) in multiple tempo projects
- `RichNote`: Created for note shaping, because when doing note shaping, we have to delete/sort/re-border more info in parallel with the notes