### PR TITLE
Fix issues about pitch export to UST mode2

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -7,7 +7,7 @@ import ui.strings.Language
 import ui.strings.initializeI18n
 
 const val APP_NAME = "UtaFormatix"
-const val APP_VERSION = "3.9"
+const val APP_VERSION = "3.9.1"
 
 suspend fun main() {
     initializeI18n(Language.English)

--- a/src/main/kotlin/io/Ust.kt
+++ b/src/main/kotlin/io/Ust.kt
@@ -342,7 +342,8 @@ object Ust {
                 // We insert startShift in PBW and PBY with width=1, as UTAU would just ignore it
                 // Theoretically this would make all pit data moved behind by 1 tick, but hey, who can tell the difference...
                 builder.appendLine("PBW=1,${mode2Pitch?.widths?.joinToString(",") { it.toString() }}")
-                builder.appendLine("PBY=${mode2Pitch?.startShift},${mode2Pitch?.shifts?.joinToString(",") { it.toString() }}")
+                builder.appendLine("PBY=${mode2Pitch?.startShift},${mode2Pitch?.shifts
+                    ?.joinToString(",") { it.toString() }}")
                 builder.appendLine("PBM=${mode2Pitch?.curveTypes?.joinToString(",")}")
                 if (mode2Pitch?.vibratoParams != null)
                     builder.appendLine("VBR=${mode2Pitch.vibratoParams.joinToString(",")}")

--- a/src/main/kotlin/io/Ust.kt
+++ b/src/main/kotlin/io/Ust.kt
@@ -338,9 +338,11 @@ object Ust {
                 builder.appendLine("PBStart=0")
 
                 val mode2Pitch = pitchDataMode2?.notes?.get(index)
-                builder.appendLine("PBS=${mode2Pitch?.start};${mode2Pitch?.startShift}")
-                builder.appendLine("PBW=${mode2Pitch?.widths?.joinToString(",") { it.toString() }}")
-                builder.appendLine("PBY=${mode2Pitch?.shifts?.joinToString(",") { it.toString() }}")
+                builder.appendLine("PBS=${mode2Pitch?.start}")
+                // We insert startShift in PBW and PBY with width=1, as UTAU would just ignore it
+                // Theoretically this would make all pit data moved behind by 1 tick, but hey, who can tell the difference...
+                builder.appendLine("PBW=1,${mode2Pitch?.widths?.joinToString(",") { it.toString() }}")
+                builder.appendLine("PBY=${mode2Pitch?.startShift},${mode2Pitch?.shifts?.joinToString(",") { it.toString() }}")
                 builder.appendLine("PBM=${mode2Pitch?.curveTypes?.joinToString(",")}")
                 if (mode2Pitch?.vibratoParams != null)
                     builder.appendLine("VBR=${mode2Pitch.vibratoParams.joinToString(",")}")

--- a/src/main/kotlin/process/RDPSimplification.kt
+++ b/src/main/kotlin/process/RDPSimplification.kt
@@ -69,13 +69,12 @@ fun simplifyShape(pointList: List<Point>, epsilon: Double): List<Point> {
 
 /**
  * Simplify given shape, which should later be described by [maxPointCount] (or less) points.
- * Note that this function will simplify with epsilon = 0.1 anyway even your input count is satisfied.
+ * Note that this function will simplify with a small epsilon anyway even your input count is satisfied.
  * Using [simplifyShape], which implements The RDP(Ramer–Douglas–Peucker) algorithm.
  * */
 fun simplifyShapeTo(pointList: List<Point>, maxPointCount: Long): List<Point> {
-    // if (pointList.size < maxPointCount) return pointList
     /* As sometimes we will have pit data that is less than 50 points, but way too dense for mode2 ust
-       So we commented this check here to make sure data will be simplified least with epsilon = 0.1. */
+       So we commented this check here to make sure data will be simplified least with epsilon = step. */
     val step = 0.05
     var epsilon = step
     while (true) {

--- a/src/main/kotlin/process/RDPSimplification.kt
+++ b/src/main/kotlin/process/RDPSimplification.kt
@@ -69,11 +69,13 @@ fun simplifyShape(pointList: List<Point>, epsilon: Double): List<Point> {
 
 /**
  * Simplify given shape, which should later be described by [maxPointCount] (or less) points.
- *
+ * Note that this function will simplify with epsilon = 0.1 anyway even your input count is satisfied.
  * Using [simplifyShape], which implements The RDP(Ramer–Douglas–Peucker) algorithm.
  * */
 fun simplifyShapeTo(pointList: List<Point>, maxPointCount: Long): List<Point> {
-    if (pointList.size < maxPointCount) return pointList
+    // if (pointList.size < maxPointCount) return pointList
+    /* As sometimes we will have pit data that is less than 50 points, but way too dense for mode2 ust
+       So we commented this check here to make sure data will be simplified least with epsilon = 0.1. */
     var epsilon = 0.1
     val step = 0.1
     while (true) {

--- a/src/main/kotlin/process/RDPSimplification.kt
+++ b/src/main/kotlin/process/RDPSimplification.kt
@@ -76,8 +76,8 @@ fun simplifyShapeTo(pointList: List<Point>, maxPointCount: Long): List<Point> {
     // if (pointList.size < maxPointCount) return pointList
     /* As sometimes we will have pit data that is less than 50 points, but way too dense for mode2 ust
        So we commented this check here to make sure data will be simplified least with epsilon = 0.1. */
-    var epsilon = 0.1
-    val step = 0.1
+    val step = 0.05
+    var epsilon = step
     while (true) {
         val result = simplifyShape(pointList, epsilon)
         if (result.count() < maxPointCount) return result

--- a/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
@@ -56,20 +56,12 @@ fun pitchToUtauMode2Track(pitch: Pitch?, notes: List<Note>, tempos: List<Tempo>)
         notePairs.map { notePair ->
             val prev = notePair.first
             val curr = notePair.second
-            /* Get an overlap between two notes when cut pit data from track to get a more smooth result.
-             Overlap is half of previous note's length, or MAX_OVERLAP_LENGTH if too large. */
-            val expectedOverlap = kotlin.math.min((prev.length * MIX_OVERLAP_RATIO).toLong(), MAX_OVERLAP_LENGTH)
-            /* But in this overlap area, we may only get points which are closer to current note than overlap, as we
-             simplify the pit data. So we get the first point in overlap area here, and calculate the actual overlap
-             we need. */
-            val overlap = curr.tickOn -
-                    (absolutePitch.firstOrNull { it.first >= (curr.tickOn - expectedOverlap) }?.first ?: curr.tickOn)
-                    // So if we can not find any data, we just get the overlap to 0 [curr.tickOn - curr.tickOn]
             NotePitchData(
                 toRelative(
-                    absolutePitch.filter { it.first >= (curr.tickOn - overlap) && it.first < curr.tickOff },
+                    absolutePitch.filter { it.first >= curr.tickOn && it.first < curr.tickOff },
                     curr.key
-                ), -overlap, tempos.bpmForNote(curr)
+                ), (absolutePitch.firstOrNull{it.first >= curr.tickOn}?.first ?: curr.tickOn) - curr.tickOn,
+                tempos.bpmForNote(curr)
             )
         }).flatten()
 

--- a/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
@@ -78,9 +78,7 @@ fun pitchToUtauMode2Track(pitch: Pitch?, notes: List<Note>, tempos: List<Tempo>)
     }
 
     return UtauMode2TrackPitchData(dotPitDataSimplified.map { currNote ->
-        if (currNote.pitch.isEmpty())
-            return@map null
-        UtauMode2NotePitchData(
+        if (currNote.pitch.isEmpty()) null else UtauMode2NotePitchData(
             currNote.bpm,
             milliSecFromTick(currNote.offset, currNote.bpm),
             currNote.pitch.first().second * 10, // *10 = semitone -> 10 cents

--- a/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
@@ -60,7 +60,7 @@ fun pitchToUtauMode2Track(pitch: Pitch?, notes: List<Note>, tempos: List<Tempo>)
                 toRelative(
                     absolutePitch.filter { it.first >= curr.tickOn && it.first < curr.tickOff },
                     curr.key
-                ), (absolutePitch.firstOrNull{it.first >= curr.tickOn}?.first ?: curr.tickOn) - curr.tickOn,
+                ), (absolutePitch.firstOrNull { it.first >= curr.tickOn }?.first ?: curr.tickOn) - curr.tickOn,
                 tempos.bpmForNote(curr)
             )
         }).flatten()


### PR DESCRIPTION
Address issues with mode2 pitch export in ust:

- Crashing on empty pit data
- Incorrect pitch caused by overlap
- Too lossy pitch simplification
- Lost pitch shift on first point