### PR TITLE
Fix case when pitch params are missing in ust pitch import

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -7,7 +7,7 @@ import ui.strings.Language
 import ui.strings.initializeI18n
 
 const val APP_NAME = "UtaFormatix"
-const val APP_VERSION = "3.10"
+const val APP_VERSION = "3.10.1"
 
 suspend fun main() {
     initializeI18n(Language.English)

--- a/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
@@ -90,8 +90,11 @@ fun pitchFromUtauMode2Track(pitchData: UtauMode2TrackPitchData?, notes: List<Not
         if (notePitch != null) {
             var tickPos = note.tickOn + tickFromMilliSec(notePitch.start, bpm)
             val startShift =
-                if (note.tickOn == lastNote?.tickOff) (lastNote.key - note.key).toDouble()
-                else notePitch.startShift / 10
+                if (note.tickOn == lastNote?.tickOff && notePitch.shifts.isNotEmpty()) {
+                    (lastNote.key - note.key).toDouble()
+                } else {
+                    notePitch.startShift / 10
+                }
             points.add(tickPos to startShift)
             for (index in notePitch.widths.indices) {
                 val width = notePitch.widths[index]


### PR DESCRIPTION
For ust ver 1.19 (maybe 1.2 as well),
When pitch params (PBS, PBY etc) are missing, startShift is set wrong.