### PR TITLE
Accept note without pitch tag when importing musicxml

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -7,7 +7,7 @@ import ui.strings.Language
 import ui.strings.initializeI18n
 
 const val APP_NAME = "UtaFormatix"
-const val APP_VERSION = "3.10.1"
+const val APP_VERSION = "3.10.2"
 
 suspend fun main() {
     initializeI18n(Language.English)

--- a/src/main/kotlin/io/MusicXml.kt
+++ b/src/main/kotlin/io/MusicXml.kt
@@ -7,6 +7,7 @@ import external.Resources
 import io.MusicXml.MXmlMeasureContent.NoteType
 import kotlinx.coroutines.await
 import kotlinx.dom.appendText
+import model.DEFAULT_KEY
 import model.DEFAULT_LYRIC
 import model.ExportResult
 import model.Format
@@ -144,7 +145,7 @@ object MusicXml {
                     return@forEach
                 }
 
-                val key = noteNode.getSingleElementByTagName("pitch").let { pitchNode ->
+                val key = noteNode.getSingleElementByTagNameOrNull("pitch")?.let { pitchNode ->
                     val step = pitchNode.getSingleElementByTagName("step").innerValue
                     val alter = pitchNode.getSingleElementByTagNameOrNull("alter")?.innerValueOrNull?.toInt()
                     val relativeKey = when (step) {
@@ -159,7 +160,7 @@ object MusicXml {
                     } + (alter ?: 0)
                     val octave = pitchNode.getSingleElementByTagName("octave").innerValue.toInt() + 1
                     octave * KEY_IN_OCTAVE + relativeKey
-                }
+                } ?: DEFAULT_KEY
 
                 val lyric = noteNode.getSingleElementByTagNameOrNull("lyric")
                     ?.getSingleElementByTagNameOrNull("text")

--- a/src/main/kotlin/model/Constants.kt
+++ b/src/main/kotlin/model/Constants.kt
@@ -7,6 +7,7 @@ const val DEFAULT_LYRIC = "あ"
 const val DEFAULT_BPM = 120.0
 const val DEFAULT_METER_HIGH = 4
 const val DEFAULT_METER_LOW = 4
+const val DEFAULT_KEY = 60
 const val KEY_CENTER_C = 60.0
 const val LOG_FRQ_CENTER_C = 5.566914341
 const val LOG_FRQ_DIFF_ONE_KEY = 0.05776226505


### PR DESCRIPTION
When importing musicxml, any note without a `<pitch>` tag interrupts the process throwing an error.
In that case, use default pitch `60=C4` instead.