### PR TITLE
Fix startShift calculation when importing pitch from ust mode2

### DIFF
--- a/src/main/kotlin/io/Ust.kt
+++ b/src/main/kotlin/io/Ust.kt
@@ -117,7 +117,7 @@ object Ust {
         // Pitch field for Mode1
         var pendingPitchBend: List<Double>? = null
         // Pitch field for Mode2
-        var pendingPBS: Pair<Double, Double>? = null
+        var pendingPBS: Pair<Double, Double?>? = null
         var pendingPBW: List<Double>? = null
         var pendingPBY: List<Double>? = null
         var pendingPBM: List<String>? = null
@@ -164,8 +164,8 @@ object Ust {
                     notePitchDataListMode2.add(
                         UtauMode2NotePitchData(
                             bpm = tempos.last().bpm,
-                            start = pendingPBS?.first ?: 0.0,
-                            startShift = pendingPBS?.second ?: 0.0,
+                            start = pendingPBS?.first,
+                            startShift = pendingPBS?.second,
                             widths = pendingPBW.orEmpty(),
                             shifts = pendingPBY.orEmpty(),
                             curveTypes = pendingPBM.orEmpty(),
@@ -211,7 +211,7 @@ object Ust {
                 line.tryGetValue("PBS")?.let {
                     val cells = it.split(';', ',')
                     val start = cells[0].toDoubleOrNull() ?: return@let
-                    val startShift = cells.getOrNull(1)?.toDoubleOrNull() ?: 0.0
+                    val startShift = cells.getOrNull(1)?.toDoubleOrNull()
                     pendingPBS = start to startShift
                 }
                 line.tryGetValue("PBW")?.let {

--- a/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
+++ b/src/main/kotlin/process/pitch/UtauMode2PitchConversion.kt
@@ -1,7 +1,6 @@
 package process.pitch
 
 import io.Ust
-import kotlin.math.roundToLong
 import model.Note
 import model.Pitch
 import model.TICKS_IN_BEAT
@@ -11,6 +10,7 @@ import process.interpolateCosineEaseInOut
 import process.interpolateCosineEaseOut
 import process.interpolateLinear
 import process.simplifyShapeTo
+import kotlin.math.roundToLong
 
 private const val SAMPLING_INTERVAL_TICK = 4L
 
@@ -20,8 +20,8 @@ data class UtauMode2TrackPitchData(
 
 data class UtauMode2NotePitchData(
     val bpm: Double?,
-    val start: Double, // msec
-    val startShift: Double, // 10 cents
+    val start: Double?, // msec, null only if the note is not applied with pitch
+    val startShift: Double?, // 10 cents
     val widths: List<Double>, // msec
     val shifts: List<Double>, // 10 cents
     val curveTypes: List<String>, // (blank)/s/r/j
@@ -87,13 +87,15 @@ fun pitchFromUtauMode2Track(pitchData: UtauMode2TrackPitchData?, notes: List<Not
     for ((note, notePitch) in notePitches) {
         val points = mutableListOf<Pair<Long, Double>>()
         if (notePitch?.bpm != null) bpm = notePitch.bpm
-        if (notePitch != null) {
+        if (notePitch?.start != null) {
             var tickPos = note.tickOn + tickFromMilliSec(notePitch.start, bpm)
             val startShift =
-                if (note.tickOn == lastNote?.tickOff && notePitch.shifts.isNotEmpty()) {
+                if (note.tickOn == lastNote?.tickOff) {
+                    // always same value as the last note
                     (lastNote.key - note.key).toDouble()
                 } else {
-                    notePitch.startShift / 10
+                    // actually in this case startShift is always 0.0
+                    (notePitch.startShift ?: 0.0) / 10
                 }
             points.add(tickPos to startShift)
             for (index in notePitch.widths.indices) {


### PR DESCRIPTION
## Background
Changes from https://github.com/sdercolin/utaformatix3/pull/92 causes issues when provided with note with only `PBS` and `PBW` paramters, which is the most simple pitch point style with only two points.

To summary the correct logic, about the startShift, we have following cases:
1.  Without any pitch parameters -> No pitch, so just do not add anything to `points`
2. At least `PBS` and `PBW` are given -> default pitch points (two point). In this case, the pitch value of the start point is always fixed as:
    i. When the note is connected to the previous note -> previous note's key
    ii. Otherwise, this note's key
    So actually PBS's y-value is totally redundant and it's sometimes omitted in the ust file. Anyway we still take it currently.

## Summary
Make `UtauMode2NotePitchData.start` and `UtauMode2NotePitchData.startShift` nullable.
If `start` is null, that means no pitch is applied to this note, thus we skip process of adding pitch points. (This solves the problem described in https://github.com/sdercolin/utaformatix3/pull/92 correctly)
About `startShift`, as stated above, it's actually not used at all; however we still make it nullable to keep original data instead of override it with `0.0`.
