### PR TITLE
Replace deprecated API usages

### DIFF
--- a/src/main/kotlin/io/VsqLike.kt
+++ b/src/main/kotlin/io/VsqLike.kt
@@ -82,7 +82,7 @@ object VsqLike {
     private fun parseTrack(trackAsText: String, trackId: Int, tickPrefix: Long, params: ImportParams): Track {
         val lines = trackAsText.linesNotBlank()
         val titleWithIndexes = lines.mapIndexed { index, line ->
-            if (line.matches("\\[.*\\]")) line.drop(1).dropLast(1) to index
+            if (Regex("\\[.*\\]").matches(line)) line.drop(1).dropLast(1) to index
             else null
         }.filterNotNull()
         val sectionMap = titleWithIndexes.zipWithNext().map { (current, next) ->

--- a/src/main/kotlin/process/lyrics/Cleanup.kt
+++ b/src/main/kotlin/process/lyrics/Cleanup.kt
@@ -20,7 +20,7 @@ fun cleanup(tracks: List<Track>, type: LyricsType) =
 private fun String.cleanupAsRomajiCV(): String {
     if (this.isEmpty()) return this
 
-    var result = this.toLowerCase()
+    var result = this.lowercase()
     result = result.trim()
     result = result.trimStart('?')
 
@@ -37,7 +37,7 @@ private fun String.cleanupAsRomajiCV(): String {
 private fun String.cleanupAsRomajiVCV(): String {
     if (this.isEmpty()) return this
 
-    var result = this.toLowerCase()
+    var result = this.lowercase()
     result = result.trim()
 
     if (!result.contains(" ")) {

--- a/src/main/kotlin/process/pitch/OpenUtauPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/OpenUtauPitchConversion.kt
@@ -118,7 +118,7 @@ fun pitchFromUstxPart(notes: List<Note>, pitchData: OpenUtauPartPitchData, bpm: 
             .groupBy { it.first }
             .filter { it.key in sectionBorder..nextSectionBorder }
             .map { (tick, points) ->
-                tick to points.sumByDouble { it.second }
+                tick to points.sumOf { it.second }
             }
 
         allPointsFromNote.addAll(pointsInSection)
@@ -134,7 +134,7 @@ fun pitchFromUstxPart(notes: List<Note>, pitchData: OpenUtauPartPitchData, bpm: 
     val pitchPoints = (allPointsFromNote + curvePoints)
         .groupBy { it.first }
         .map { (tick, points) ->
-            tick to points.sumByDouble { it.second }
+            tick to points.sumOf { it.second }
         }
         .sortedBy { it.first }
 
@@ -148,7 +148,7 @@ fun mergePitchFromUstxParts(first: Pitch?, second: Pitch?): Pitch? {
         .mapNotNull { point -> point.second?.let { point.first to it } }
         .groupBy { it.first }
         .map { (tick, points) ->
-            tick to points.sumByDouble { it.second }
+            tick to points.sumOf { it.second }
         }
         .sortedBy { it.first }
     return first.copy(data = data)


### PR DESCRIPTION
Some APIs have become deprecated after migrating to Kotlin 1.6.21.