### PR TITLE
Show unsupported standard midi file error

### DIFF
--- a/src/main/kotlin/exception/UnsupportedFileFormatError.kt
+++ b/src/main/kotlin/exception/UnsupportedFileFormatError.kt
@@ -1,0 +1,10 @@
+package exception
+
+import ui.strings.Strings
+import ui.strings.string
+
+open class UnsupportedFileFormatError(override val message: String) : Exception(message)
+
+class UnsupportedStandardMidiError : UnsupportedFileFormatError(
+    string(Strings.UnsupportedStandardMidiError)
+)

--- a/src/main/kotlin/ui/Importer.kt
+++ b/src/main/kotlin/ui/Importer.kt
@@ -3,6 +3,7 @@ package ui
 import ImportParamsJson
 import csstype.VerticalAlign
 import csstype.px
+import exception.UnsupportedFileFormatError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -67,6 +68,7 @@ val Importer = scopedFC<ImporterProps> { props, scope ->
                 files,
                 fileFormat,
                 setLoading = { isLoading = it },
+                onSnackBarError = { snackbarError = it },
                 onDialogError = { dialogError = it },
                 props,
                 params
@@ -173,6 +175,7 @@ private fun import(
     files: List<File>,
     format: Format,
     setLoading: (Boolean) -> Unit,
+    onSnackBarError: (SnackbarErrorState) -> Unit,
     onDialogError: (DialogErrorState) -> Unit,
     props: ImporterProps,
     params: ImportParams
@@ -190,13 +193,17 @@ private fun import(
         }.onFailure { t ->
             console.log(t)
             setLoading(false)
-            onDialogError(
-                DialogErrorState(
-                    isShowing = true,
-                    title = string(Strings.ImportErrorDialogTitle),
-                    message = t.stackTraceToString()
+            if (t is UnsupportedFileFormatError) {
+                onSnackBarError(SnackbarErrorState(true, t.message))
+            } else {
+                onDialogError(
+                    DialogErrorState(
+                        isShowing = true,
+                        title = string(Strings.ImportErrorDialogTitle),
+                        message = t.stackTraceToString()
+                    )
                 )
-            )
+            }
         }
     }
 }

--- a/src/main/kotlin/ui/strings/Strings.kt
+++ b/src/main/kotlin/ui/strings/Strings.kt
@@ -319,6 +319,11 @@ enum class Strings(
         ru = "Неподдерживаемый формат файла",
         fr = "Type de fichier non supporté"
     ),
+    UnsupportedStandardMidiError(
+        en = "Standard MIDI file format is not supported",
+        ja = "Standard MIDIファイル形式はサポートされていません",
+        zhCN = "不支持标准MIDI文件格式"
+    ),
     MultipleFileImportError(
         en = "Multiple files of {{format}} could not be imported in one go",
         ja = "複数の{{format}}ファイルを一度にインポートすることはできません",


### PR DESCRIPTION
It's not an unexpected exception so we should show a readable error to user.