### PR TITLE
Remove negative positioned notes from parsed svp

### DIFF
--- a/src/main/kotlin/io/Svp.kt
+++ b/src/main/kotlin/io/Svp.kt
@@ -73,7 +73,9 @@ object Svp {
         model.Track(
             id = index,
             name = track.name ?: "Track ${index + 1}",
-            notes = parseNotes(track, project),
+            notes = parseNotes(track, project)
+                // for some reasons, svp can have negative positioned notes inside
+                .filter { it.tickOn >= 0 },
             pitch = if (params.simpleImport) null else parsePitch(track, project, tempos),
         ).validateNotes()
     }


### PR DESCRIPTION
SVP seems to have notes with `onset < 0`.
Those notes seems not accessible in the application so we can remove them after parsing.
Otherwise a `IllegalNotePositionException` is thrown.