### PR TITLE
Fix regex used in vsq/mid import

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -6,7 +6,7 @@ import ui.strings.Language
 import ui.strings.initializeI18n
 
 const val APP_NAME = "UtaFormatix"
-const val APP_VERSION = "3.15"
+const val APP_VERSION = "3.15.1"
 
 suspend fun main() {
     initializeI18n(Language.English)

--- a/src/main/kotlin/io/VsqLike.kt
+++ b/src/main/kotlin/io/VsqLike.kt
@@ -83,7 +83,8 @@ object VsqLike {
     private fun parseTrack(trackAsText: String, trackId: Int, tickPrefix: Long, params: ImportParams): Track {
         val lines = trackAsText.linesNotBlank()
         val titleWithIndexes = lines.mapIndexed { index, line ->
-            if (Regex("\\[.*]").matches(line)) line.drop(1).dropLast(1) to index
+            @Suppress("RegExpRedundantEscape")
+            if (Regex("""\[.*\]""").matches(line)) line.drop(1).dropLast(1) to index
             else null
         }.filterNotNull()
         val sectionMap = titleWithIndexes.zipWithNext().map { (current, next) ->


### PR DESCRIPTION
Seems we cannot omit the `\` on the right bracket.
Something wrong with the IDE warning.