### PR TITLE
Handle negative positioned input pitch points from ustx

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -6,7 +6,7 @@ import ui.strings.Language
 import ui.strings.initializeI18n
 
 const val APP_NAME = "UtaFormatix"
-const val APP_VERSION = "3.15.1"
+const val APP_VERSION = "3.15.2"
 
 suspend fun main() {
     initializeI18n(Language.English)

--- a/src/main/kotlin/process/pitch/OpenUtauPitchConversion.kt
+++ b/src/main/kotlin/process/pitch/OpenUtauPitchConversion.kt
@@ -140,6 +140,7 @@ fun pitchFromUstxPart(notes: List<Note>, pitchData: OpenUtauPartPitchData, tempo
             tick to points.sumOf { it.second }
         }
         .sortedBy { it.first }
+        .filter { it.first >= 0 }
 
     return if (pitchPoints.isEmpty()) null else Pitch(pitchPoints, isAbsolute = false)
 }

--- a/src/main/kotlin/process/pitch/TickTimeTransformation.kt
+++ b/src/main/kotlin/process/pitch/TickTimeTransformation.kt
@@ -32,7 +32,8 @@ class TickTimeTransformer(
         }
 
     fun tickToSec(tick: Long) = segments
-        .first { tick in it.range }
+        .firstOrNull { tick in it.range }
+        .let { it ?: segments.first() }
         .let { it.offset + (tick - it.range.first) * it.secPerTick }
 
     fun tickToMilliSec(tick: Long) = tickToSec(tick) * 1000
@@ -42,7 +43,8 @@ class TickTimeTransformer(
     fun tickDistanceToMilliSec(tickStart: Long, tickEnd: Long) = tickDistanceToSec(tickStart, tickEnd) * 1000
 
     fun secToTick(sec: Double) = segments
-        .last { it.offset <= sec }
+        .lastOrNull { it.offset <= sec }
+        .let { it ?: segments.first() }
         .let { ((sec - it.offset) / it.secPerTick).toLong() + it.range.first }
 
     fun milliSecToTick(milliSec: Double) = secToTick(milliSec / 1000.0)

--- a/src/test/kotlin/process/pitch/TickTimeTransformerTest.kt
+++ b/src/test/kotlin/process/pitch/TickTimeTransformerTest.kt
@@ -39,4 +39,13 @@ class TickTimeTransformerTest {
         val expected = 3.0
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun testNegativeInput() {
+        val second = -5.0
+        val tick = -5000L
+        println(transformer.secToTick(second))
+        assertEquals(tick, transformer.secToTick(second))
+        assertEquals(second, transformer.tickToSec(tick))
+    }
 }


### PR DESCRIPTION
Sometimes we get negative positioned points like
- note starting from 0 tick
- point is `(-40, ...)`

So
- Allow negative values in `TickTimeTransformer`
- Remove points with negative positions at the last