### PR TITLE
Fix extremely large tempo in imported ust

### DIFF
--- a/src/main/kotlin/io/Ust.kt
+++ b/src/main/kotlin/io/Ust.kt
@@ -66,6 +66,15 @@ object Ust {
         }
         val warnings = mutableListOf<ImportWarning>()
         val tempos = results.firstOrNull { it.tempos.isNotEmpty() }?.tempos
+            ?.let {
+                // fix extremely large tempo
+                if (it.first().tickPosition == 0L && it.first().bpm > MAX_ACCEPTED_BPM) {
+                    warnings.add(ImportWarning.DefaultTempoFixed(it.first().bpm))
+                    listOf(Tempo.default) + it.drop(1)
+                } else {
+                    it
+                }
+            }
             ?: listOf(Tempo.default).also {
                 warnings.add(ImportWarning.TempoNotFound)
             }
@@ -424,5 +433,6 @@ object Ust {
 
     const val MODE1_PITCH_SAMPLING_INTERVAL_TICK = 5L
     const val MODE2_PITCH_MAX_POINT_COUNT = 50L
+    private const val MAX_ACCEPTED_BPM = 10000.0
     private const val LINE_SEPARATOR = "\r\n"
 }

--- a/src/main/kotlin/model/ImportWarning.kt
+++ b/src/main/kotlin/model/ImportWarning.kt
@@ -7,6 +7,7 @@ sealed class ImportWarning {
     class TempoIgnoredInFile(val file: File, val tempo: Tempo) : ImportWarning()
     class TempoIgnoredInTrack(val track: Track, val tempo: Tempo) : ImportWarning()
     class TempoIgnoredInPreMeasure(val tempo: Tempo) : ImportWarning()
+    class DefaultTempoFixed(val originalBpm: Double) : ImportWarning()
     object TimeSignatureNotFound : ImportWarning()
     class TimeSignatureIgnoredInTrack(val track: Track, val timeSignature: TimeSignature) : ImportWarning()
     class TimeSignatureIgnoredInPreMeasure(val timeSignature: TimeSignature) : ImportWarning()

--- a/src/main/kotlin/ui/OutputFormatSelector.kt
+++ b/src/main/kotlin/ui/OutputFormatSelector.kt
@@ -118,6 +118,10 @@ private val ImportWarning.text: String
             Strings.ImportWarningTempoIgnoredInPreMeasure,
             "bpm" to tempo.bpm.toString(),
         )
+        is ImportWarning.DefaultTempoFixed -> string(
+            Strings.ImportWarningDefaultTempoFixed,
+            "bpm" to originalBpm.toString(),
+        )
         is ImportWarning.TimeSignatureNotFound -> string(Strings.ImportWarningTimeSignatureNotFound)
         is ImportWarning.TimeSignatureIgnoredInTrack -> string(
             Strings.ImportWarningTimeSignatureIgnoredInTrack,

--- a/src/main/kotlin/ui/strings/Strings.kt
+++ b/src/main/kotlin/ui/strings/Strings.kt
@@ -477,6 +477,13 @@ enum class Strings(
         ru = "- Метка темпа ({{bpm}}) в предварительных мерах была проигнорирована.",
         fr = "- Le tempo ({{bpm}}) dans les pré-mesures a été ignorée.",
     ),
+    ImportWarningDefaultTempoFixed(
+        en = "- Default tempo was too large ({{bpm}}), so it was fixed to 120.",
+        ja = "- デフォルトテンポが大きすぎる（{{bpm}}）ので、120に修正しました。",
+        zhCN = "- 默认速度过大（{{bpm}}），已修正为120。",
+        ru = "- Темп по умолчанию слишком большой ({{bpm}}), поэтому он был исправлен на 120.",
+        fr = "- Le tempo par défaut était trop grand ({{bpm}}), il a donc été fixé à 120.",
+    ),
     ImportWarningTimeSignatureNotFound(
         en = "- No time signature labels found in the imported project.",
         ja = "- 拍子記号が見つかりませんでした。",


### PR DESCRIPTION
## Summary
When importing ust, fix the default tempo if it's too large (over 10000.0 bpm) to default (120.0).
A new import warning is added in that case.

#### Original report
`This may be known, but there's a common midi import bug with original UTAU. It causes the default tempo to be "50000". If you try to convert a UST that has this issue (or that has remnants of this issue EG the tempo from tick 1 is correct so works in UTAU, but the base tempo is still 50k) to CCS it comes into VoiSona empty. It does work with CeVIO CS7, and other CCS files (converted and native) work as expected in VoiSona`