### PR TITLE
Fix music xml import to use default tempo and time signatures

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -6,7 +6,7 @@ import ui.strings.Language
 import ui.strings.initializeI18n
 
 const val APP_NAME = "UtaFormatix"
-const val APP_VERSION = "3.18.2"
+const val APP_VERSION = "3.18.3"
 
 suspend fun main() {
     initializeI18n(Language.English)


### PR DESCRIPTION
Allow lacking tempo/time signatures in music xml.