### PR TITLE
Add: Support analysis for lyrics with suffix

### DIFF
--- a/src/jsMain/kotlin/process/lyrics/japanese/Analysis.kt
+++ b/src/jsMain/kotlin/process/lyrics/japanese/Analysis.kt
@@ -42,7 +42,11 @@ private fun analyseLyricsTypeForTrack(track: Track): JapaneseLyricsType {
 }
 
 private fun checkNoteType(note: Note): JapaneseLyricsType {
-    val lyric = note.lyric
+    var lyric = note.lyric
+    // Suffix (e.g. "_B4")
+    if (lyric.contains("_")) {
+        lyric = lyric.substring(0, lyric.indexOf("_"))
+    }
     if (lyric.contains(" ")) {
         val mainLyric = lyric.substring(lyric.indexOf(" ") + 1)
         if (mainLyric.isKana) return KanaVcv


### PR DESCRIPTION
This PR adds support for lyrics with suffix. This is helpful when the utau library provides multiple tones (idk how to say this in English, 多音階音源).


Example: [tsukuyomi_cvc.zip](https://github.com/sdercolin/utaformatix3/files/15321838/tsukuyomi_cvc.zip)
