### PR TITLE
 Add: Allow specifying default lyrics via ImportParams

### DIFF
--- a/core/src/main/kotlin/core/io/MusicXml.kt
+++ b/core/src/main/kotlin/core/io/MusicXml.kt
@@ -141,7 +141,7 @@ object MusicXml {
         trackIndex: Int,
         partNode: Element,
         masterTrackResult: MasterTrackParseResult,
-        defaultLyric: String
+        defaultLyric: String,
     ): Track {
         val trackName = "Track ${trackIndex + 1}"
         val notes = mutableListOf<Note>()

--- a/core/src/main/kotlin/core/io/S5p.kt
+++ b/core/src/main/kotlin/core/io/S5p.kt
@@ -1,6 +1,5 @@
 package core.io
 
-import core.model.DEFAULT_LYRIC
 import core.model.ExportNotification
 import core.model.ExportResult
 import core.model.Feature
@@ -69,7 +68,7 @@ object S5p {
             core.model.Track(
                 id = index,
                 name = track.name ?: "Track ${index + 1}",
-                notes = parseNotes(track),
+                notes = parseNotes(track, params.defaultLyric),
                 pitch = if (params.simpleImport) null else parsePitch(track),
             ).validateNotes()
         }
@@ -91,16 +90,17 @@ object S5p {
         return Pitch(convertedPoints, isAbsolute = false).takeIf { it.data.isNotEmpty() }
     }
 
-    private fun parseNotes(track: Track): List<core.model.Note> = track.notes.filterNotNull().map { note ->
-        val tickOn = note.onset / TICK_RATE
-        core.model.Note(
-            id = 0,
-            key = note.pitch,
-            tickOn = tickOn,
-            tickOff = tickOn + note.duration / TICK_RATE,
-            lyric = note.lyric.takeUnless { it.isNullOrBlank() } ?: DEFAULT_LYRIC,
-        )
-    }
+    private fun parseNotes(track: Track, defaultLyric: String): List<core.model.Note> =
+        track.notes.filterNotNull().map { note ->
+            val tickOn = note.onset / TICK_RATE
+            core.model.Note(
+                id = 0,
+                key = note.pitch,
+                tickOn = tickOn,
+                tickOff = tickOn + note.duration / TICK_RATE,
+                lyric = note.lyric.takeUnless { it.isNullOrBlank() } ?: defaultLyric,
+            )
+        }
 
     fun generate(project: core.model.Project, features: List<FeatureConfig>): ExportResult {
         val jsonText = generateContent(project, features)

--- a/core/src/main/kotlin/core/io/Vpr.kt
+++ b/core/src/main/kotlin/core/io/Vpr.kt
@@ -2,7 +2,6 @@ package core.io
 
 import core.external.JsZip
 import core.external.JsZipOption
-import core.model.DEFAULT_LYRIC
 import core.model.ExportNotification
 import core.model.ExportResult
 import core.model.Feature
@@ -71,7 +70,7 @@ object Vpr {
                     id = index,
                     tickOn = tickOffset + note.pos,
                     tickOff = tickOffset + note.pos + note.duration,
-                    lyric = note.lyric.takeUnless { it.isNullOrBlank() } ?: DEFAULT_LYRIC,
+                    lyric = note.lyric.takeUnless { it.isNullOrBlank() } ?: params.defaultLyric,
                     key = note.number,
                     phoneme = note.phoneme,
                 )

--- a/core/src/main/kotlin/core/io/VsqLike.kt
+++ b/core/src/main/kotlin/core/io/VsqLike.kt
@@ -1,7 +1,6 @@
 package core.io
 
 import core.exception.EmptyProjectException
-import core.model.DEFAULT_LYRIC
 import core.model.ExportNotification
 import core.model.ExportResult
 import core.model.Feature
@@ -123,7 +122,7 @@ object VsqLike {
                 }
                 val (lyric, xSampa) = lyricsInfo?.let {
                     it[0].trim('"') to it[1].trim('"')
-                } ?: (DEFAULT_LYRIC to null)
+                } ?: (params.defaultLyric to null)
                 Note(
                     id = 0,
                     key = key,

--- a/core/src/main/kotlin/core/io/Vsqx.kt
+++ b/core/src/main/kotlin/core/io/Vsqx.kt
@@ -1,7 +1,6 @@
 package core.io
 
 import core.exception.IllegalFileException
-import core.model.DEFAULT_LYRIC
 import core.model.ExportNotification
 import core.model.ExportResult
 import core.model.Feature
@@ -200,7 +199,8 @@ object Vsqx {
                 val key = noteNode.getSingleElementByTagName(tagNames.noteNum).innerValue.toInt()
                 val tickOn = noteNode.getSingleElementByTagName(tagNames.posTick).innerValue.toLong()
                 val length = noteNode.getSingleElementByTagName(tagNames.duration).innerValue.toLong()
-                val lyric = noteNode.getSingleElementByTagNameOrNull(tagNames.lyric)?.innerValueOrNull ?: DEFAULT_LYRIC
+                val lyric =
+                    noteNode.getSingleElementByTagNameOrNull(tagNames.lyric)?.innerValueOrNull ?: params.defaultLyric
                 val xSampa = noteNode.getSingleElementByTagNameOrNull(tagNames.xSampa)?.innerValueOrNull
                 Note(
                     id = index,

--- a/core/src/main/kotlin/core/model/Format.kt
+++ b/core/src/main/kotlin/core/model/Format.kt
@@ -105,8 +105,8 @@ enum class Format(
     MusicXml(
         "musicxml",
         otherExtensions = listOf("xml"),
-        parser = { files, _ ->
-            core.io.MusicXml.parse(files.first())
+        parser = { files, params ->
+            core.io.MusicXml.parse(files.first(), params)
         },
         generator = { project, _ ->
             core.io.MusicXml.generate(project)
@@ -152,8 +152,8 @@ enum class Format(
     ),
     StandardMid(
         "mid",
-        parser = { files, _ ->
-            core.io.StandardMid.parse(files.first())
+        parser = { files, params ->
+            core.io.StandardMid.parse(files.first(), params)
         },
         generator = { project, _ ->
             core.io.StandardMid.generate(project)
@@ -165,8 +165,8 @@ enum class Format(
     ),
     Ppsf(
         "ppsf",
-        parser = { files, _ ->
-            core.io.Ppsf.parse(files.first())
+        parser = { files, params ->
+            core.io.Ppsf.parse(files.first(), params)
         },
         generator = { _, _ ->
             throw NotImplementedError()

--- a/core/src/main/kotlin/core/model/ImportParams.kt
+++ b/core/src/main/kotlin/core/model/ImportParams.kt
@@ -6,4 +6,5 @@ import kotlinx.serialization.Serializable
 data class ImportParams(
     val simpleImport: Boolean = false,
     val multipleMode: Boolean = false,
+    val defaultLyric: String = "あ",
 )


### PR DESCRIPTION
This pr allows specifying default lyrics via ImportParams, rather than "あ".
This is useful when library users want to notes without default lyrics set.

I kept `DEFAULT_LYRIC` in Constants.kt because it's used in `StandardMid`, but it's more natural that not inserting lyric event when no lyrics are set.