### PR TITLE
Accept string ustx_version when parsing ustx files

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,9 +13,10 @@ jobs:
             -   uses: actions/checkout@v4
 
             -   name: Set up JDK 21
-                uses: actions/setup-java@v1
+                uses: actions/setup-java@v4
                 with:
-                    java-version: 21
+                    java-version: '21'
+                    distribution: 'corretto'
 
             -   name: Grant execute permission for gradlew
                 run: chmod +x gradlew

--- a/core/src/main/kotlin/core/io/Ustx.kt
+++ b/core/src/main/kotlin/core/io/Ustx.kt
@@ -18,9 +18,19 @@ import core.process.pitch.pitchFromUstxPart
 import core.process.pitch.reduceRepeatedPitchPointsFromUstxTrack
 import core.process.pitch.toOpenUtauPitchData
 import core.util.readText
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
 import org.w3c.files.Blob
 import org.w3c.files.BlobPropertyBag
 import org.w3c.files.File
@@ -343,13 +353,39 @@ object Ustx {
             ignoreUnknownKeys = true
         }
 
+    /**
+     * `ustx_version` is written as a number (e.g. 0.6) by older OpenUtau versions
+     * and as a string (e.g. "0.9.1") by newer ones; accept both, and keep the
+     * numeric form on output so exported files match the template.
+     */
+    private object VersionSerializer : KSerializer<String> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UstxVersion", PrimitiveKind.STRING)
+
+        override fun deserialize(decoder: Decoder): String =
+            (decoder as JsonDecoder).decodeJsonElement().jsonPrimitive.content
+
+        override fun serialize(
+            encoder: Encoder,
+            value: String,
+        ) {
+            val doubleValue = value.toDoubleOrNull()
+            if (doubleValue != null) {
+                (encoder as JsonEncoder).encodeJsonElement(JsonPrimitive(doubleValue))
+            } else {
+                encoder.encodeString(value)
+            }
+        }
+    }
+
     @Serializable
     private data class Project(
         val name: String,
         val comment: String,
         @SerialName("output_dir") val outputDir: String,
         @SerialName("cache_dir") val cacheDir: String,
-        @SerialName("ustx_version") val ustxVersion: Double,
+        @SerialName("ustx_version")
+        @Serializable(with = VersionSerializer::class)
+        val ustxVersion: String,
         val bpm: Double? = null,
         @SerialName("beat_per_bar") val beatPerBar: Int? = null,
         @SerialName("beat_unit") val beatUnit: Int? = null,

--- a/src/jsTest/kotlin/io/UstxTest.kt
+++ b/src/jsTest/kotlin/io/UstxTest.kt
@@ -1,0 +1,66 @@
+package io
+
+import core.io.Ustx
+import core.model.ImportParams
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+import org.w3c.files.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(DelicateCoroutinesApi::class)
+class UstxTest {
+    private fun ustxContent(version: String) =
+        """
+        name: New Project
+        comment: ''
+        output_dir: Vocal
+        cache_dir: UCache
+        ustx_version: $version
+        bpm: 120
+        beat_per_bar: 4
+        beat_unit: 4
+        resolution: 480
+        expressions: {}
+        tracks:
+        - phonemizer: OpenUtau.Api.DefaultPhonemizer
+          mute: false
+          solo: false
+          volume: 0
+          track_name: Track 1
+        voice_parts:
+        - name: New Part
+          comment: ''
+          track_no: 0
+          position: 0
+          notes:
+          - position: 0
+            duration: 480
+            tone: 60
+            lyric: あ
+            pitch:
+              data:
+              - {x: -40, y: 0, shape: io}
+              snap_first: true
+            vibrato: {length: 0, period: 175, depth: 25, in: 10, out: 10, shift: 0, drift: 0}
+        """.trimIndent()
+
+    private fun parse(version: String) =
+        GlobalScope.promise {
+            val file = File(arrayOf(ustxContent(version)), "test.ustx")
+            val project = Ustx.parse(file, ImportParams())
+            assertEquals(1, project.tracks.size)
+            val notes = project.tracks.first().notes
+            assertEquals(1, notes.size)
+            assertEquals("あ", notes.first().lyric)
+        }
+
+    // older OpenUtau writes the version as a number
+    @Test
+    fun testParseNumberVersion() = parse("0.6")
+
+    // newer OpenUtau writes it as a string (issue #191)
+    @Test
+    fun testParseStringVersion() = parse("'0.9.1'")
+}


### PR DESCRIPTION
## Summary
- Fixes #191: newer OpenUtau versions write `ustx_version` as a string (e.g. `"0.9.1"`) instead of a number, which crashed `.ustx` import with `Failed to parse type 'double' for input '0.9.1'`.
- `Ustx.Project.ustxVersion` is now a `String` with a custom serializer that accepts both the numeric form (old OpenUtau) and the string form (new OpenUtau). On export, numeric values are still written as numbers, so exported files are unchanged from before.
- Adds `UstxTest` covering both version forms — the first test for the `core/io` parsers.
- Also bumps the deprecated `actions/setup-java@v1` to `v4` in the PR workflow (aligned with deploy.yml's Corretto distribution).

## Test plan
- [x] `./gradlew build ktlintCheck` passes locally (JDK 21)
- [x] New `UstxTest` parses `.ustx` with `ustx_version: 0.6` and `ustx_version: '0.9.1'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)